### PR TITLE
Add approx_size for String and Symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 .mempool
+Manifest.toml

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -100,6 +100,14 @@ function approx_size(xs::AbstractArray{String})
     s + 4 * length(xs)
 end
 
+function approx_size(s::String) 
+    sizeof(s)+8
+end
+
+function approx_size(s::Symbol) 
+    0
+end
+
 function __init__()
     global session = "sess-" * randstring(5)
     try

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -101,11 +101,11 @@ function approx_size(xs::AbstractArray{String})
 end
 
 function approx_size(s::String) 
-    sizeof(s)+8
+    sizeof(s)+sizeof(Int) # sizeof(Int) for 64 bit vs 32 bit systems
 end
 
 function approx_size(s::Symbol) 
-    0
+    sizeof(s)+sizeof(Int)
 end
 
 function __init__()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,14 @@ end
     @test !isassigned(sa2, 2)
 end
 
+@testset "approx_size $(typeof(x))" for x in (
+    "foo~^å&",
+    SubString("aaaaa", 2),
+    Symbol("foo~^å&")
+)
+    @test MemPool.approx_size(x) == Base.summarysize(x)
+end
+
 mutable struct Empty
 end
 import Base: ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,10 +72,14 @@ end
 @testset "approx_size $(typeof(x))" for x in (
     "foo~^å&",
     SubString("aaaaa", 2),
-    Symbol("foo~^å&")
 )
     @test MemPool.approx_size(x) == Base.summarysize(x)
 end
+@testset "approx_size Symbol" begin
+    s = Symbol("foo~^å&")
+    @test MemPool.approx_size(s) == Base.summarysize(String(s))
+end
+
 
 mutable struct Empty
 end


### PR DESCRIPTION
Not sure if the implementation for Symbol is really what one wants, but it does yeild the exact same result as Base.summarysize.

Benchmarks:

### String

Before:
```julia
julia> @benchmark MemPool.approx_size("aaaa")
BenchmarkTools.Trial: 
  memory estimate:  608 bytes
  allocs estimate:  7
  --------------
  minimum time:     350.000 ns (0.00% GC)
  median time:      375.701 ns (0.00% GC)
  mean time:        511.096 ns (7.43% GC)
  maximum time:     15.956 μs (96.76% GC)
  --------------
  samples:          10000
  evals/sample:     214
```
After:
```julia
julia> @benchmark MemPool.approx_size("aaaa")
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.200 ns (0.00% GC)
  median time:      1.300 ns (0.00% GC)
  mean time:        1.559 ns (0.00% GC)
  maximum time:     57.100 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```

### Symbol
Before:
```julia
julia> @benchmark MemPool.approx_size(:aaaa)
BenchmarkTools.Trial: 
  memory estimate:  576 bytes
  allocs estimate:  5
  --------------
  minimum time:     211.193 ns (0.00% GC)
  median time:      243.303 ns (0.00% GC)
  mean time:        315.998 ns (9.53% GC)
  maximum time:     7.154 μs (89.33% GC)
  --------------
  samples:          10000
  evals/sample:     545
```
After:
```julia
julia> @benchmark MemPool.approx_size(:aaaa)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.001 ns (0.00% GC)
  median time:      0.001 ns (0.00% GC)
  mean time:        0.027 ns (0.00% GC)
  maximum time:     0.100 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```