### PR TITLE
Abstract out network for poolget/poolset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "MemPool"
 uuid = "f9f48841-c794-520a-933b-121f7ba6ed94"
 license = "MIT"
 desc = "a simple distributed data store"
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -5,6 +5,7 @@ import Serialization: serialize, deserialize
 export DRef, FileRef, poolset, poolget, pooldelete, destroyonevict,
        movetodisk, copytodisk, savetodisk, mmwrite, mmread, cleanup,
        deletefromdisk, poolref, poolunref
+using Distributed
 import .Threads: ReentrantLock
 
 ## Wrapping-unwrapping of payloads:
@@ -49,6 +50,7 @@ unwrap_payload(f::FileRef) = unwrap_payload(open(deserialize, f.file, "r+"))
 
 include("io.jl")
 include("lock.jl")
+include("networks.jl")
 include("datastore.jl")
 
 """

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -1,0 +1,9 @@
+# Network transfer abstractions
+
+struct DistributedNetwork end
+
+initialize(net::DistributedNetwork, procs) = nothing
+Distributed.remotecall_fetch(net::DistributedNetwork, args...) =
+    Distributed.remotecall_fetch(args...)
+Distributed.remotecall_fetch(f::Function, net::DistributedNetwork, args...) =
+    Distributed.remotecall_fetch(f, args...)


### PR DESCRIPTION
This lets us use UCX to service `poolget`/`poolset` transfers, or any other protocol which can implement `Distributed.remotecall_fetch`.