### PR TITLE
Allow DRef size to be nothing

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -54,10 +54,11 @@ include("datastore.jl")
 """
 `approx_size(d)`
 
-Returns the size of `d` in bytes used for accounting in MemPool datastore.
+Returns the size of `d` in bytes used for accounting in MemPool datastore, or
+returns `nothing` if the size cannot be calculated efficiently.
 """
 function approx_size(@nospecialize(d))
-    Base.summarysize(d) # note: this is accurate but expensive
+    nothing # Skip size calculation
 end
 
 function approx_size(d::Union{Base.BitInteger, Float16, Float32, Float64})
@@ -86,7 +87,7 @@ function approx_size(T, L, d)
     elseif isempty(d)
         return 0
     else
-        return sum(approx_size(x) for x in d)
+        return sum(something(approx_size(x), 0) for x in d)
     end
 end
 
@@ -100,11 +101,11 @@ function approx_size(xs::AbstractArray{String})
     s + 4 * length(xs)
 end
 
-function approx_size(s::String) 
+function approx_size(s::String)
     sizeof(s)+sizeof(Int) # sizeof(Int) for 64 bit vs 32 bit systems
 end
 
-function approx_size(s::Symbol) 
+function approx_size(s::Symbol)
     sizeof(s)+sizeof(Int)
 end
 

--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -4,7 +4,7 @@ using Distributed
 mutable struct DRef
     owner::Int
     id::Int
-    size::UInt
+    size::Union{UInt,Nothing}
     function DRef(owner, id, size)
         d = new(owner, id, size)
         poolref(d)
@@ -50,7 +50,7 @@ Base.copy(d::DRef) = deepcopy(d)
 Base.deepcopy(d::DRef) = DRef(d.owner, d.id, d.size)
 
 mutable struct RefState
-    size::UInt64
+    size::Union{UInt64, Nothing}
     data::Union{Some{Any}, Nothing}
     file::Union{String, Nothing}
     destroyonevict::Bool # if true, will be removed from memory

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,6 +140,15 @@ end
     pooldelete(d1)
 end
 
+@testset "DRef size" begin
+    struct MyStruct end
+    d1 = poolset(1)
+    d2 = poolset(MyStruct())
+    @test d1.size == sizeof(Int)
+    @test d2.size === nothing
+    pooldelete.((d1, d2))
+end
+
 @testset "set-get-delete" begin
     r1 = poolset([1,2])
     r2 = poolset(["abc","def"], 2)


### PR DESCRIPTION
Instead of performing an expensive `Base.summarysize` when calculating the size of arbitrary objects for storing as a `DRef`, we now set the size to `nothing` if we don't have a method for computing `approx_size` of the object. This should alleviate performance concerns reported at https://github.com/JuliaParallel/Dagger.jl/issues/204#issuecomment-782425405; I will post a matching Dagger PR soon to make use of this new change.

@DrChainsaw this should be of interest to you!