### PR TITLE
fix finalizer task switch

### DIFF
--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -113,9 +113,9 @@ function _enqueue_work(f, args...; gc_context=false)
             if trylock(SEND_QUEUE)
                 try
                     put!(SEND_QUEUE, (f, args))
+                    break
                 finally
                     unlock(SEND_QUEUE)
-                    break
                 end
             end
         end


### PR DESCRIPTION
Fixes task switch during finalizer, which started surfacing after fixing these finalizer task switches https://github.com/JuliaLang/julia/pull/41846

Stress testing (running tons of dtable loads/ops in a loop) the active waiting got at most one iteration in the while loop, so even if it has to wait it leaves that state pretty much immediately.

```
error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")
jl_error at /opt/julia/src/rtutils.c:41
jl_switch at /opt/julia/src/task.c:481
try_yieldto at ./task.jl:754
wait at ./task.jl:824
wait at ./condition.jl:112
lock at ./lock.jl:100
lock at ./condition.jl:73 [inlined]
lock at ./channels.jl:424 [inlined]
put_buffered at ./channels.jl:320
put! at ./channels.jl:316
unknown function (ip: 0x7f82a06574b0)
_enqueue_work at /home/krynju/.julia/packages/MemPool/RPu2r/src/datastore.jl:111
#25 at /home/krynju/.julia/packages/MemPool/RPu2r/src/datastore.jl:152
macro expansion at /home/krynju/.julia/packages/MemPool/RPu2r/src/lock.jl:62 [inlined]
with_datastore_lock at /home/krynju/.julia/packages/MemPool/RPu2r/src/datastore.jl:204
poolunref at /home/krynju/.julia/packages/MemPool/RPu2r/src/datastore.jl:144
poolunref at /home/krynju/.julia/packages/MemPool/RPu2r/src/datastore.jl:143
jl_apply at /opt/julia/src/julia.h:1768 [inlined]
run_finalizer at /opt/julia/src/gc.c:278
jl_gc_run_finalizers_in_list at /opt/julia/src/gc.c:365
run_finalizers at /opt/julia/src/gc.c:394 [inlined]
run_finalizers at /opt/julia/src/gc.c:372
jl_gc_collect at /opt/julia/src/gc.c:3266
maybe_collect at /opt/julia/src/gc.c:881 [inlined]
jl_gc_pool_alloc at /opt/julia/src/gc.c:1205
unknown function (ip: 0x7f82a06676af)
jl_apply at /opt/julia/src/julia.h:1768 [inlined]
start_task at /opt/julia/src/task.c:880
```