### PR TITLE
`GC.safepoint` added when actively waiting using trylocks

### DIFF
--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -110,6 +110,7 @@ function _enqueue_work(f, args...; gc_context=false)
     end
     if gc_context
         while true
+            GC.safepoint()
             if trylock(SEND_QUEUE)
                 try
                     put!(SEND_QUEUE, (f, args))

--- a/src/lock.jl
+++ b/src/lock.jl
@@ -56,6 +56,7 @@ macro safe_lock_spin(l, ex)
         temp = $(esc(l))
         while !trylock(temp)
             # we can't yield here
+            GC.safepoint()
         end
         enable_finalizers(false) # retains compatibility with non-finalizer callers
         try


### PR DESCRIPTION
addresses the nasty https://github.com/JuliaParallel/Dagger.jl/issues/288

But I guess this will need to be revisited as apparently you can lock in finalizers now?
This will do for now, will let the DTable benchmarks run properly