### PR TITLE
Add automatic swap-to-disk support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 .mempool
 Manifest.toml
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 DataStructures = "0.18"
-julia = "1.4"
+julia = "1.7"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "MemPool"
 uuid = "f9f48841-c794-520a-933b-121f7ba6ed94"
 license = "MIT"
 desc = "a simple distributed data store"
-version = "0.3.9"
+version = "0.4.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -2,7 +2,7 @@ module MemPool
 
 using Serialization, Sockets, Random
 import Serialization: serialize, deserialize
-export DRef, FileRef, poolset, poolget, pooldelete, destroyonevict,
+export DRef, FileRef, poolset, poolget, pooldelete,
        movetodisk, copytodisk, savetodisk, mmwrite, mmread, cleanup,
        deletefromdisk, poolref, poolunref
 import .Threads: ReentrantLock
@@ -109,27 +109,56 @@ function approx_size(s::Symbol)
 end
 
 function __init__()
-    global session = "sess-" * randstring(5)
+    global session = "sess-" * randstring(6)
     try
         global host = getipaddr()
     catch err
         global host = Sockets.localhost
     end
-    datastore_lock[] = NonReentrantLock()
-    id_counter[] = Atomic{Int}(0)
     if parse(Bool, get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR", "0"))
         membound = parse(Int, get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_MEMORY_BOUND", repr(8*(1024^3))))
-        diskpath = get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_DISK_CACHE", joinpath(tempdir(), ".mempool"))
-        rootdir = Sys.iswindows() ? "C:" : "/"
-        diskdevice = SerializationFileDevice(FilesystemResource(rootdir), diskpath)
+        diskpath = get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_DISK_CACHE", joinpath(default_dir(), randstring(6)))
+        diskdevice = SerializationFileDevice(FilesystemResource(), diskpath)
         diskbound = parse(Int, get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_DISK_BOUND", repr(32*(1024^3))))
-        GLOBAL_DEVICE[] = LRUAllocator(membound, diskdevice, diskbound)
-    end
-    atexit() do
-        for id in keys(datastore)
-            datastore_delete(id)
+        kind = get(ENV, "JULIA_MEMPOOL_EXPERIMENTAL_ALLOCATOR_KIND", "MRU")
+        if !(kind in ("LRU", "MRU"))
+            @warn "Unknown allocator kind: $kind\nDefaulting to MRU"
+            kind = "MRU"
         end
+        GLOBAL_DEVICE[] = SimpleRecencyAllocator(membound, diskdevice, diskbound, Symbol(kind))
+    end
+
+    # Ensure we cleanup all references
+    atexit() do
         exit_flag[] = true
+        kill_counter = 10
+        empty!(file_to_dref)
+        empty!(who_has_read)
+        while kill_counter > 0 && with_lock(()->!isempty(datastore), datastore_lock)
+            GC.gc()
+            sleep(1)
+            kill_counter -= 1
+        end
+        with_lock(datastore_lock) do
+            if length(datastore) > 0
+                @warn "Failed to cleanup datastore after 10 seconds\nForcibly evicting all entries"
+                for id in collect(keys(datastore))
+                    state = MemPool.datastore[id]
+                    device = storage_read(state).root
+                    if device !== nothing
+                        @debug "Evicting ref $id with device $device"
+                        try
+                            delete_from_device!(device, state, id)
+                        catch
+                        end
+                    end
+                    delete!(MemPool.datastore, id)
+                end
+            end
+        end
+        if ispath(default_dir())
+            rm(default_dir(); recursive=true)
+        end
     end
 end
 

--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -140,7 +140,7 @@ function _enqueue_work(f, args...; gc_context=false)
                     iob = IOContext(IOBuffer(), :color=>true)
                     println(iob, "Error in enqueued work:")
                     Base.showerror(iob, err)
-                    seek(iob, 0)
+                    seek(iob.io, 0)
                     write(stderr, iob)
                 end
             end

--- a/src/fsinfo.jl
+++ b/src/fsinfo.jl
@@ -1,0 +1,71 @@
+@static if Sys.isunix()
+
+struct StatFSStruct
+    f_bsize::Culong
+    f_frsize::Culong
+    f_blocks::Culong
+    f_bfree::Culong
+    f_bavail::Culong
+    f_files::Culong
+    f_ffree::Culong
+    f_favail::Culong
+    f_fsid::Culong
+    f_flag::Culong
+    f_namemax::Culong
+    reserved::NTuple{6,Cint}
+end
+
+function statvfs(path::String)
+    buf = Ref{StatFSStruct}()
+    GC.@preserve buf begin
+        errno = ccall(:statvfs, Cint, (Cstring, Ptr{StatFSStruct}), path, buf)
+        if errno != 0
+            Base.systemerror(errno)
+        end
+        buf[]
+    end
+end
+
+struct MntEntStruct
+    mnt_fsname::Cstring
+    mnt_dir::Cstring
+    mnt_type::Cstring
+    mnt_opts::Cstring
+    mnt_freq::Cint
+    mnt_passno::Cint
+end
+struct MntEntry
+    mnt_fsname::String
+    mnt_dir::String
+    mnt_type::String
+    mnt_opts::String
+    mnt_freq::Cint
+    mnt_passno::Cint
+end
+
+function getmounts(path::String="/etc/fstab")
+    bufs = MntEntry[]
+    mnt = ccall(:setmntent, Ptr{Cvoid}, (Cstring, Cstring), path, "r")
+    Base.systemerror("Failed to setmntent at $path", UInt64(mnt) == 0)
+    while true
+        ret = ccall(:getmntent, Ptr{MntEntStruct}, (Ptr{Cvoid},), mnt)
+        UInt64(ret) == 0 && break
+        buf = unsafe_load(ret)
+        push!(bufs, MntEntry(
+            deepcopy(unsafe_string(buf.mnt_fsname)),
+            deepcopy(unsafe_string(buf.mnt_dir)),
+            deepcopy(unsafe_string(buf.mnt_type)),
+            deepcopy(unsafe_string(buf.mnt_opts)),
+            buf.mnt_freq,
+            buf.mnt_passno
+        ))
+    end
+    ccall(:endmntent, Cvoid, (Ptr{Cvoid},), mnt)
+    bufs
+end
+
+else
+
+error("Not implemented yet")
+
+end

--- a/src/fsinfo.jl
+++ b/src/fsinfo.jl
@@ -1,5 +1,6 @@
 if Sys.isunix()
 
+if !isdefined(Base, :diskstat)
 struct StatFSStruct
     f_bsize::Culong
     f_frsize::Culong
@@ -33,6 +34,7 @@ function disk_stats(path::String)
         capacity = vfs.f_blocks * vfs.f_bsize
     )
 end
+end # diskstat
 
 struct MntEntStruct
     mnt_fsname::Cstring
@@ -75,6 +77,7 @@ mountpoints() = map(mnt->mnt.mnt_dir, getmntent())
 
 elseif Sys.iswindows()
 
+if !isdefined(Base, :diskstat)
 function disk_stats(path::String)
     lpDirectoryName = path
     lpFreeBytesAvailableToCaller = Ref{Int64}(0)
@@ -96,6 +99,7 @@ function disk_stats(path::String)
         capacity = lpTotalNumberOfBytes[]
     )
 end
+end # diskstat
 
 function mountpoints()
     mounts = String[]
@@ -118,6 +122,16 @@ end
 else
 
 mountpoints() = error("Not implemented yet")
+if !isdefined(Base, :diskstat)
 disk_stats(path::String) = error("Not implemented yet")
+end
 
+end
+
+if isdefined(Base, :diskstat)
+function disk_stats(path::String)
+    stats = Base.diskstat(path)
+    return (available=stats.available,
+            capacity=stats.total)
+end
 end

--- a/src/lock.jl
+++ b/src/lock.jl
@@ -67,3 +67,19 @@ macro safe_lock_spin(l, ex)
         end
     end
 end
+
+"""
+    with_lock(f, lock, cond=true)
+
+Conditionally take lock `lock`, execute `f`, and unlock `lock`. If `!cond`,
+then `lock` is not taken or released.
+"""
+function with_lock(f, lock, cond=true)
+    if cond
+        @safe_lock lock begin
+            f()
+        end
+    else
+        f()
+    end
+end

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1,0 +1,282 @@
+abstract type StorageResource end
+
+struct CPURAMResource <: StorageResource end
+
+struct FilesystemResource <: StorageResource
+    mountpoint::String
+end
+
+"""
+    StorageDevice
+
+The abstract supertype of all storage devices. A `StorageDevice` must implement
+`movetodevice!`, `readfromdevice`, and `deletefromdevice!`. A `StorageDevice`
+may reflect a mechanism for storing data on persistent storage, or it may be an
+allocator which manages other `StorageDevice`s.
+
+See the `SerializationFileDevice` for an example of how to implement a data
+store.
+
+When implementing an allocator, it's recommended to provide options that users
+can tune to control how many bytes of storage may be used for each managed
+`StorageDevice`. This makes it easier for users to predict the amount of
+storage that a given piece of code can use. See the `LRUAllocator` for a simple
+example of how to implement an allocator.
+"""
+abstract type StorageDevice end
+
+"Returns the storage handle referring to the data contained in reference `id`."
+storage_handle(id::Int) = (datastore[id].file::StorageState).handle
+
+"Returns the true storage device for reference `id`."
+function storage_device(id::Int)
+    rstate = datastore[id]
+    if rstate.data !== nothing
+        return CPURAMDevice()
+    end
+    (rstate.file::StorageState).device
+end
+
+"""
+    writetodevice!(device::StorageDevice, id::Int)
+
+Writes reference `id`'s data to `device`. Reads the data into memory first (via
+`readfromdevice(CPURAMDevice(), id)`) if necessary.
+"""
+writetodevice!
+
+"""
+    readfromdevice(device::StorageDevice, id::Int, ret::Bool) -> Any
+
+Access the value of reference `id` from `device`, and return it if `ret` is
+`true`; if `ret` is `false`, then the value is not actually retrieved, but
+internal counters may be updated to account for this access.
+
+Callers must ensure that the data is currently stored on `device` before
+calling this. Callees that read/write data directly must set
+`datastore[id].data` appropriately when `ret` is `true`.
+"""
+readfromdevice
+
+"Force a read into memory from the true storage device."
+function readfromdevice(id::Int)
+    s = datastore[id]
+    if !isinmemory(s)
+        readfromdevice((s.file::StorageState).device, id, true)
+    end
+    something(s.data)
+end
+
+"""
+    deletefromdevice!(device::StorageDevice, id::Int)
+
+Delete reference `id`'s data from `device`, such that upon return, the space
+used by the previously-referenced data is now available for allocating to other
+data.
+"""
+deletefromdevice!
+
+"""
+    CPURAMDevice <: StorageDevice
+
+Stores data in memory. This is the default device.
+"""
+struct CPURAMDevice <: StorageDevice end
+function writetodevice!(device::CPURAMDevice, ref_id)
+    s = datastore[ref_id]
+    if !isinmemory(s)
+        sstate = s.file::StorageState
+        data = readfromdevice(sstate.device, ref_id, true)
+        s.data = Some{Any}(data)
+    end
+    return ref_id
+end
+readfromdevice(::CPURAMDevice, ref_id, ret) = ret ? something(datastore[ref_id].data) : nothing
+function deletefromdevice!(::CPURAMDevice, ref_id)
+    datastore[ref_id].data = nothing
+end
+
+"""
+    SerializationFileDevice <: StorageDevice
+
+Stores data in a temporary file, using the `Serialization` stdlib to write and
+read data.
+"""
+struct SerializationFileDevice <: StorageDevice
+    fs::FilesystemResource
+    dir::String
+end
+"Construct a `SerializationFileDevice` which stores data in the directory `dir`."
+SerializationFileDevice(dir) =
+    SerializationFileDevice(FilesystemResource(Sys.iswindows() ? "C:" : "/"), dir)
+SerializationFileDevice() =
+    SerializationFileDevice(joinpath(tempdir(), ".mempool"))
+function writetodevice!(device::SerializationFileDevice, ref_id)
+    mkpath(device.dir)
+    path = tempname(device.dir; cleanup=false)
+    s = datastore[ref_id]
+    fref = FileRef(path, s.size)
+    open(path, "w") do io
+        serialize(io, MMWrap(something(s.data)))
+    end
+    _writetodevice!(ref_id, device, fref)
+    return ref_id
+end
+function readfromdevice(device::SerializationFileDevice, id, ret)
+    if ret
+        datastore[id].data !== nothing && return
+        fref = storage_handle(id)
+        data = unwrap_payload(open(deserialize, fref.file, "r+"))
+        datastore[id].data = Some{Any}(data)
+        data
+    end
+end
+function deletefromdevice!(device::SerializationFileDevice, id)
+    fref = storage_handle(id)
+    rm(fref.file; force=true)
+    datastore[id].file = nothing
+end
+
+struct StorageState
+    device::StorageDevice
+    handle
+end
+
+"""
+    LRUAllocator <: StorageDevice
+
+A simple LRU allocator device which manages an `upper` device and a `lower`
+device. The `upper` device is be limited to `upper_limit` bytes of storage;
+when an allocation exceeds this limit, the least recently accessed data will be
+moved to the `lower` device (which is unbounded), and the new allocation will
+be moved to the `upper` device.
+
+Consider using an `upper` device of `CPURAMDevice` and a `lower` device of
+`SerializationFileDevice` to implement a basic swap-to-disk allocator. Such a
+device will be created and used automatically if the environment variable
+`JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR` is set to `1` or `true`.
+"""
+struct LRUAllocator <: StorageDevice
+    mem_limit::UInt64
+    device::StorageDevice
+    device_limit::UInt64
+    mem_refs::Vector{Int}
+    device_refs::Vector{Int}
+end
+LRUAllocator(mem_limit, device, device_limit) =
+    LRUAllocator(mem_limit, device, device_limit, Int[], Int[])
+function writetodevice!(lru::LRUAllocator, ref_id)
+    ref_state = datastore[ref_id]
+    if ref_state.size > lru.mem_limit
+        # Won't fit in memory, can we demote?
+        if ref_state.size > lru.device_limit
+            # Too bulky, won't fit in device either
+            throw(ArgumentError("DRef data for ID $ref_id too large!"))
+        end
+        # Demote to device immediately
+        lru_migrate!(lru, ref_id, false)
+        deletefromdevice!(CPURAMDevice(), ref_id)
+        @assert ref_state.file !== nothing
+        return
+    end
+    lru_migrate!(lru, ref_id, true)
+end
+function lru_migrate!(lru::LRUAllocator, ref_id, to_mem)
+    ref_size = datastore[ref_id].size
+    if to_mem
+        # Demoting to device
+        from_refs = lru.mem_refs
+        from_limit = lru.mem_limit
+        from_device = CPURAMDevice()
+        to_refs = lru.device_refs
+        to_limit = lru.device_limit
+        to_device = lru.device
+    else
+        # Promoting to memory
+        from_refs = lru.device_refs
+        from_limit = lru.device_limit
+        from_device = lru.device
+        to_refs = lru.mem_refs
+        to_limit = lru.mem_limit
+        to_device = CPURAMDevice()
+    end
+    from_size = sum(map(x->datastore[x].size, from_refs))
+    to_size = sum(map(x->datastore[x].size, to_refs))
+    idx = to_mem ? lastindex(from_refs) : firstindex(from_refs)
+    # TODO: Plan migrations to determine feasibility
+    while ref_size + from_size > from_limit
+        # Demote older/promote newer refs until space is available
+        @assert 1 <= idx <= length(from_refs) "Failed to make $ref_size bytes of space available"
+        oref = from_refs[idx]
+        oref_size = datastore[oref].size
+        if oref_size + to_size <= to_limit
+            # Destination has space for this ref
+            readfromdevice(from_device, oref, true)
+            # N.B. We `writetodevice!` before deleting from old device, in case
+            # the write fails (so we don't lose data)
+            if to_mem
+                writetodevice!(to_device, oref)
+            end
+            push!(to_refs, oref)
+            deletefromdevice!(from_device, oref)
+            deleteat!(from_refs, idx)
+            @assert something(datastore[oref].data, datastore[oref].file) !== nothing
+            from_size -= oref_size
+            to_size += oref_size
+        end
+        idx += to_mem ? -1 : 1
+    end
+
+    # Space available, perform migration
+    readfromdevice(ref_id)
+    writetodevice!(from_device, ref_id)
+    pushfirst!(from_refs, ref_id)
+    if (idx = findfirst(x->x==ref_id, to_refs)) !== nothing
+        deletefromdevice!(to_device, ref_id)
+        deleteat!(to_refs, idx)
+        @assert something(datastore[ref_id].data, datastore[ref_id].file) !== nothing
+    end
+end
+function readfromdevice(lru::LRUAllocator, id, ret)
+    if (idx = findfirst(x->x==id, lru.mem_refs)) !== nothing
+        deleteat!(lru.mem_refs, idx)
+        pushfirst!(lru.mem_refs, id)
+        readfromdevice(CPURAMDevice(), id, ret)
+    else
+        idx = findfirst(x->x==id, lru.device_refs)
+        @assert idx !== nothing
+        lru_migrate!(lru, id, true)
+        device = storage_device(id)
+        readfromdevice(device, id, ret)
+    end
+end
+function deletefromdevice!(lru::LRUAllocator, id)
+    if (idx = findfirst(x->x==id, lru.mem_refs)) !== nothing
+        deletefromdevice!(CPURAMDevice(), lru.mem_refs[idx])
+        deleteat!(lru.mem_refs, idx)
+    else
+        idx = findfirst(x->x==id, lru.device_refs)
+        @assert idx !== nothing
+        deletefromdevice!(lru.device, lru.device_refs[idx])
+        deleteat!(lru.device_refs, idx)
+    end
+end
+
+function setdevice!(device::StorageDevice, id)
+    old_device = device_map[id]
+    old_device == device && return
+    readfromdevice(device, id, true)
+    writetodevice!(device, id)
+    deletefromdevice!(old_device, id)
+    device_map[id] = device
+end
+function setdevice!(device::StorageDevice, ref::DRef)
+    if ref.owner == myid()
+        setdevice!(device, ref.id)
+    else
+        remotecall_wait(setdevice!, ref.owner, ref.id)
+    end
+end
+
+const GLOBAL_DEVICE = Ref{StorageDevice}(CPURAMDevice())
+const device_map = Dict{Int,StorageDevice}()

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1,3 +1,142 @@
+"""
+# Storage System Design
+
+## Overview
+
+MemPool implements a data storage system for allowing automated transfers of
+DRef-associated data to storage media. The storage system is designed for the
+"swap-to-disk" use case, where some portion of data is kept on-disk, and
+swapped into memory as-needed, to support out-of-core operations. The storage
+system is designed to be performant, flexible, and user-configurable, allowing
+all kinds of definitions of "disk" to be implemented (including network stores,
+tape drives, etc.).
+
+The storage system is rooted on two abstract types, the `StorageResource`, and
+the `StorageDevice`. Briefly, a `StorageResource` represents some finite
+storage medium (such as a hard disk-backed filesystem, an S3 bucket, etc.),
+while a `StorageDevice` represents a mechanism by which data can be written to
+and read from an associated `StorageResource`. For example, the built-in
+`FilesystemResource` is a `StorageResource` which represents a mounted
+filesystem, while the `SerializationFileDevice` is a `StorageDevice` which can
+store data on a `FilesystemResource` as a set of files written using the
+`Serialization` stdlib format. Other `StorageResource`s and `StorageDevice`s
+may be implemented by libraries or users to suit the specific storage medium
+and use case.
+
+All DRefs have an associated `StorageDevice`, which manages the reference's
+data. The global device is available at `GLOBAL_DEVICE[]`, and may be
+set by the user to whatever device is most desirable as a default. When a DRef
+is created with `poolset`, a "root" `StorageDevice` will be associated which
+manages the reference's data, either directly, or indirectly by managing other
+`StorageDevice`s. For example, the built-in `SimpleRecencyAllocator` can use assigned as
+the root device to manage a `CPURAMDevice` and a `SerializationFileDevice` to
+provide automatic swap-to-disk in a least-recently-used fashion.
+
+## Entrypoints
+
+The entrypoints of the storage system are:
+- `poolset` - Writes the data at DRef creation time
+- `poolget` - Reads the data to return it to the caller
+- GC finalization - Unaccessible DRefs cause the data to be deleted
+
+The associated internal storage functions are (respectively):
+- `write_to_device!` - Writes the data from memory to the device
+- `read_from_device` - Reads the data into memory from the device
+- `delete_from_device!` - Deletes the data from the device
+- `retain_on_device!` - Controls whether data is retained on device upon deletion
+
+The internal storage functions don't map exactly to the entrypoints; a
+`poolget` might require writing some unrelated data from memory to disk before
+the desired data can be read from disk to memory, and both existing data
+locations will then probably need to be deleted to minimize storage usage.
+
+## Internal Consistency
+
+To allow for concurrent storage operations on unrelated data, the storage
+system uses a set of locks and atomics/read-copy-update to ensure safe and
+consistent access to data, while minimizing unnecessary wait time.
+
+Globally, the datastore maintains a single lock that protects access to the
+mapping from DRef ID to the associated `RefState` object. The `RefState` object
+contains everything necessary to access and manipulate the DRef's data, and the
+object is maintained for the lifetime of the DRef, allowing it to be cached and
+threaded through function to minimize datastore lock contention. This globally
+datastore lock is thus a short point of contention which should only rarely
+need to be accessed (ideally only once, and very briefly, per storage
+entrypoint).
+
+The `RefState` object contains some basic information about the data, including
+its estimated size in memory. Most importantly, it also points to a
+`StorageState` object, which contains all of the information relevant to
+storing and retrieving the data. The `StorageState` field of `RefState` is
+atomically accessed, ensuring it always points to a valid object.
+
+The `StorageState` itself contains fields for the root device, the "leaf"
+devices (the devices which physically performs reads/writes/deletes), the
+in-memory data (if any), and the on-device data (if any). The `StorageState`'s
+fields are not always safe to access; thus, they are protected by a field
+containing a `Base.Event`, which indicates when the other fields are safe to
+access. Once the event has been notified, all other fields may be safely read
+from. Any `getproperty` call to a `StorageState` field waits on this event to
+complete, which ensures that all in-flight operations have completed.
+
+In order to transition data to-and-from memory and disk, the `StorageState`
+contained in the `RefState` can be atomically swapped with a new one which
+represents the new state of the DRef's data. Making such a transition occurs
+with the `storage_rcu!` helper, which can safely construct a new
+`StorageState`, and install it as the new "source of truth". This helper uses
+the read-copy-update pattern, or RCU, to ensure that new `StorageState` is
+always based on the existing `StorageState`. Pairing with this helper is
+`storage_read`, which can safely read the current `StorageState` from its
+`RefState`.
+
+This setup allows devices to safely determine the current state of a DRef's
+data, and to ensure that all readers can see a fully-formed `StorageState`
+object. This also makes it easy to ensure that data is never accidentally lost
+by two conflicting transitions. However, it is important to note that by the
+time a field of a read `StorageState` is accessed, the current state of the
+DRef's data may have changed. This is not normally something to worry about;
+whatever `StorageState` was just read can treated as the (temporary) source of
+truth. Of course, `StorageState`s should thus never be cached or reused, as
+they can quickly become stale, and doing so might preserve excessive data.
+
+This system also has the benefit of providing concurrent and lazy storage
+operations; the `StorageState` for a `RefState` may be transitioned before the
+actual data transfer completes, and synchronization will only occur when the
+`StorageState` is later accessed. And any two tasks which operate on different
+DRefs (and which have their associated `RefState`s available) may never content
+with each other.
+
+## Queries
+
+MemPool provides utilities to query `StorageResource`s and `StorageDevice`s for
+their capacity and current utilization. The `storage_capacity`,
+`storage_utilization`, and `storage_available` utilities work as expected on
+`StorageResource` objects, and return values in bytes. Additionally, because
+`StorageDevice`s can access multiple `StorageResource`s, the same utilities can
+also be optionally passed a `StorageResource` object to limit queries to that
+specific resource.
+
+## Limits and Limitations
+
+Devices like the `SimpleRecencyAllocator` set byte limits on how much data may
+reside in memory and on disk. These limits are, unfortunately, not exact or
+guaranteed, because of the nature of Julia's GC, and an inability of MemPool to
+intercept user allocations. Thus, the ability of such devices to manage memory
+or report the correct amount of storage media utilization is limited, and
+should be taken as an approximation.
+
+Additionally, leaf devices may report a storage utilization level that varies
+according to external forces, such as by allocations from other processes on
+the system, or fluctuations in OS memory management. The `externally_varying`
+query on a `StorageDevice` will return `true` if the device is subject to such
+unpredictable variation. A result of `false` implies that the device is not
+aware of such variation, and lives in an "ideal world" where the device fully
+controls all storage variations; of course, this is an approximation of
+reality, and does not actually reflect how much of the physical resources are
+truly available.
+"""
+
 include("fsinfo.jl")
 
 """
@@ -41,6 +180,7 @@ storage_capacity(::CPURAMResource) = Sys.total_memory()
 struct FilesystemResource <: StorageResource
     mountpoint::String
 end
+FilesystemResource() = FilesystemResource(Sys.iswindows() ? "C:" : "/")
 storage_available(s::FilesystemResource) = disk_stats(s.mountpoint).available
 storage_capacity(s::FilesystemResource) = disk_stats(s.mountpoint).capacity
 
@@ -48,7 +188,7 @@ storage_capacity(s::FilesystemResource) = disk_stats(s.mountpoint).capacity
     StorageDevice
 
 The abstract supertype of all storage devices. A `StorageDevice` must implement
-`movetodevice!`, `readfromdevice`, and `deletefromdevice!`. A `StorageDevice`
+`movetodevice!`, `read_from_device`, and `delete_from_device!`. A `StorageDevice`
 may reflect a mechanism for storing data on persistent storage, or it may be an
 allocator which manages other `StorageDevice`s.
 
@@ -58,8 +198,8 @@ store.
 When implementing an allocator, it's recommended to provide options that users
 can tune to control how many bytes of storage may be used for each managed
 `StorageDevice`. This makes it easier for users to predict the amount of
-storage that a given piece of code can use. See the `LRUAllocator` for a simple
-example of how to implement an allocator.
+storage that a given piece of code can use. See the `SimpleRecencyAllocator`
+for a (relatively) simple example of how to implement an allocator.
 """
 abstract type StorageDevice end
 
@@ -67,62 +207,194 @@ abstract type StorageDevice end
 storage_available(dev::StorageDevice) = sum(res->storage_available(dev, res), storage_resources(dev))
 storage_capacity(dev::StorageDevice) = sum(res->storage_capacity(dev, res), storage_resources(dev))
 storage_utilized(dev::StorageDevice) = sum(res->storage_utilized(dev, res), storage_resources(dev))
+check_same_resource(dev::StorageDevice, expected::StorageResource, res::StorageResource) =
+    (expected === res) || throw(ArgumentError("Invalid storage resource $res for device $dev"))
+storage_available(dev::StorageDevice, res::StorageResource) =
+    throw(ArgumentError("Invalid storage resource $res for device $dev"))
+storage_capacity(dev::StorageDevice, res::StorageResource) =
+    throw(ArgumentError("Invalid storage resource $res for device $dev"))
+storage_utilized(dev::StorageDevice, res::StorageResource) =
+    throw(ArgumentError("Invalid storage resource $res for device $dev"))
 
-"Returns the storage handle referring to the data contained in reference `id`."
-storage_handle(id::Int) = (datastore[id].file::StorageState).handle
-
-"Returns the true storage device for reference `id`."
-function storage_device(id::Int)
-    rstate = datastore[id]
-    if rstate.data !== nothing
-        return CPURAMDevice()
-    end
-    (rstate.file::StorageState).device
+mutable struct StorageLeaf
+    # A low-level storage device
+    device::StorageDevice
+    # The handle associated with the device
+    handle::Union{Some{Any}, Nothing}
+    # Whether to retain the underlying data
+    retain::Bool
 end
-storage_device(ref::DRef) =
-    (@assert ref.owner == myid(); storage_device(ref.id))
+StorageLeaf(device, handle) = StorageLeaf(device, handle, false)
+StorageLeaf(device) = StorageLeaf(device, nothing, false)
+
+"Safely copies a `Vector{StorageLeaf}` for later mutation."
+copy_leaves(leaves::Vector{StorageLeaf}) =
+    StorageLeaf[StorageLeaf(leaf.device, leaf.handle, leaf.retain) for leaf in leaves]
+
+mutable struct StorageState
+    # The in-memory value of the reference
+    data::Union{Some{Any}, Nothing}
+    # The low-level devices and handles physically storing the reference's values
+    leaves::Vector{StorageLeaf}
+    # The high-level device managing the reference's values
+    root::StorageDevice
+    # Notifies waiters when all fields become useable
+    ready::Base.Event
+end
+StorageState(data, leaves, root) =
+    StorageState(data, leaves, root, Base.Event())
+StorageState(old::StorageState;
+             data=old.data,
+             leaves=old.leaves,
+             root=old.root) = StorageState(data, leaves, root,
+                                           Base.Event())
+
+function Base.getproperty(sstate::StorageState, field::Symbol)
+    if field == :ready
+        return getfield(sstate, :ready)
+    end
+
+    wait(sstate.ready)
+    return getfield(sstate, field)
+end
+Base.notify(sstate::StorageState) = notify(sstate.ready)
+Base.wait(sstate::StorageState) = wait(sstate.ready)
+
+mutable struct RefState
+    # The storage state associated with the reference and its values
+    @atomic storage::StorageState
+    # The estimated size that the values of the reference take in memory
+    size::UInt64
+end
+function Base.getproperty(state::RefState, field::Symbol)
+    if field === :storage
+        throw(ArgumentError("Cannot directly read :storage field of RefState\nUse storage_read(state) instead"))
+    end
+    return getfield(state, field)
+end
+function Base.setproperty!(state::RefState, field::Symbol, value)
+    if field === :storage
+        throw(ArgumentError("Cannot directly write :storage field of RefState\nUse storage_rcu!(f, state) instead"))
+    end
+    return setfield!(state, field, value)
+end
+Base.show(io::IO, state::RefState) =
+    print(io, "RefState(size=$(Base.format_bytes(state.size)))")
 
 "Returns the size of the data for reference `id`."
-storage_size(id::Int) = datastore[id].size
+storage_size(ref::DRef) =
+    (@assert ref.owner == myid(); storage_size(ref.id))
+storage_size(id::Int) =
+    storage_size(with_lock(()->datastore[id], datastore_lock))
+storage_size(state::RefState) = state.size
 
 """
-    writetodevice!(device::StorageDevice, id::Int)
+    write_to_device!(device::StorageDevice, state::RefState, id::Int)
 
 Writes reference `id`'s data to `device`. Reads the data into memory first (via
-`readfromdevice(CPURAMDevice(), id)`) if necessary.
+`read_from_device(CPURAMDevice(), id)`) if necessary.
 """
-writetodevice!
+function write_to_device! end
+write_to_device!(state::RefState, ref::DRef) =
+    write_to_device!(storage_read(state).root, state, ref.id)
+write_to_device!(device::StorageDevice, ref::DRef) =
+    write_to_device!(device, with_lock(()->datastore[ref.id], datastore_lock), ref.id)
+write_to_device!(device::StorageDevice, state::RefState, ref::DRef) =
+    write_to_device!(device, state, ref.id)
+write_to_device!(state::RefState, id::Int) =
+    write_to_device!(storage_read(state).root, state, id)
+write_to_device!(device::StorageDevice, id::Int) =
+    write_to_device!(device, with_lock(()->datastore[id], datastore_lock), id)
 
 """
-    readfromdevice(device::StorageDevice, id::Int, ret::Bool) -> Any
+    read_from_device(device::StorageDevice, state::RefState, id::Int, ret::Bool) -> Any
 
 Access the value of reference `id` from `device`, and return it if `ret` is
 `true`; if `ret` is `false`, then the value is not actually retrieved, but
-internal counters may be updated to account for this access.
-
-Callers must ensure that the data is currently stored on `device` before
-calling this. Callees that read/write data directly must set
-`datastore[id].data` appropriately when `ret` is `true`.
+internal counters may be updated to account for this access. Also ensures that
+the values for reference `id` are in memory; if necessary, they will be read
+from the reference's true storage device.
 """
-readfromdevice
-
-"Force a read into memory from the true storage device."
-function readfromdevice(id::Int)
-    s = datastore[id]
-    if !isinmemory(s)
-        readfromdevice((s.file::StorageState).device, id, true)
-    end
-    something(s.data)
-end
+function read_from_device end
+read_from_device(state::RefState, ref::DRef, ret::Bool) =
+    read_from_device(storage_read(state).root, state, ref.id, ret)
+read_from_device(device::StorageDevice, ref::DRef, ret::Bool) =
+    read_from_device(device, with_lock(()->datastore[ref.id], datastore_lock), ref.id, ret)
+read_from_device(device::StorageDevice, state::RefState, ref::DRef, ret::Bool) =
+    read_from_device(device, state, ref.id, ret)
+read_from_device(state::RefState, id::Int, ret::Bool) =
+    read_from_device(storage_read(state).root, state, id, ret)
+read_from_device(device::StorageDevice, id::Int, ret::Bool) =
+    read_from_device(device, with_lock(()->datastore[id], datastore_lock), id, ret)
 
 """
-    deletefromdevice!(device::StorageDevice, id::Int)
+    delete_from_device!(device::StorageDevice, state::RefState, id::Int)
 
 Delete reference `id`'s data from `device`, such that upon return, the space
 used by the previously-referenced data is now available for allocating to other
 data.
 """
-deletefromdevice!
+function delete_from_device! end
+delete_from_device!(state::RefState, ref::DRef) =
+    delete_from_device!(storage_read(state).root, state, ref.id)
+delete_from_device!(device::StorageDevice, ref::DRef) =
+    delete_from_device!(device, with_lock(()->datastore[ref.id], datastore_lock), ref.id)
+delete_from_device!(device::StorageDevice, state::RefState, ref::DRef) =
+    delete_from_device!(device, state, ref.id)
+delete_from_device!(state::RefState, id::Int) =
+    delete_from_device!(storage_read(state).root, state, id)
+delete_from_device!(device::StorageDevice, id::Int) =
+    delete_from_device!(device, with_lock(()->datastore[id], datastore_lock), id)
+
+"""
+    retain_on_device!(device::StorageDevice, state::RefState, id::Int, retain::Bool; all::Bool=false)
+
+Sets the retention state of reference `id` for `device`. If `retain` is `false`
+(the default when references are created), then data will be deleted from
+`device` upon a call to `delete_from_device!`; if `retain` is `true`, then the
+data will continue to exist on the device (if possible) upon a call to
+`delete_from_device!`.
+
+If the `all` kwarg is set to `true`, then any registered leaf devices will have
+their retain value set to `retain`.
+
+    retain_on_device!(device::StorageDevice, retain::Bool)
+
+Sets the retention state of all references stored on `device` (if possible).
+"""
+function retain_on_device! end
+retain_on_device!(state::RefState, ref::DRef, retain::Bool; kwargs...) =
+    retain_on_device!(storage_read(state).root, state, ref.id, retain; kwargs...)
+retain_on_device!(device::StorageDevice, ref::DRef, retain::Bool; kwargs...) =
+    retain_on_device!(device, with_lock(()->datastore[ref.id], datastore_lock), ref.id, retain; kwargs...)
+retain_on_device!(device::StorageDevice, state::RefState, ref::DRef, retain::Bool; kwargs...) =
+    retain_on_device!(device, state, ref.id, retain; kwargs...)
+retain_on_device!(state::RefState, id::Int, retain::Bool; kwargs...) =
+    retain_on_device!(storage_read(state).root, state, id, retain; kwargs...)
+retain_on_device!(device::StorageDevice, id::Int, retain::Bool; kwargs...) =
+    retain_on_device!(device, with_lock(()->datastore[id], datastore_lock), id, retain; kwargs...)
+function retain_on_device!(device::StorageDevice, state::RefState, id::Int, retain::Bool; all=false)
+    notify(storage_rcu!(state) do sstate
+        devices = if all && device === sstate.root
+            map(l->l.device, sstate.leaves)
+        else
+            [device]
+        end
+        leaves = copy_leaves(sstate.leaves)
+        for device in devices
+            idx = findfirst(l->l.device === device, leaves)
+            if idx === nothing
+                throw(ArgumentError("Invalid device $device"))
+            end
+            leaf = leaves[idx]
+            leaves[idx] = StorageLeaf(leaf.device, leaf.handle, retain)
+        end
+        return StorageState(sstate; leaves)
+    end)
+    return
+end
+
+retain_on_device!(device::StorageDevice, retain::Bool) = nothing
 
 """
     externally_varying(device::StorageDevice) -> Bool
@@ -149,86 +421,150 @@ externally_varying(::StorageDevice) = true
 Stores data in memory. This is the default device.
 """
 struct CPURAMDevice <: StorageDevice end
-storage_resources(dev::CPURAMDevice) = Set{StorageResource}(CPURAMResource())
+storage_resources(dev::CPURAMDevice) = Set{StorageResource}([CPURAMResource()])
 storage_capacity(::CPURAMDevice, res::CPURAMResource) = storage_capacity(res)
 storage_capacity(::CPURAMDevice) = storage_capacity(CPURAMResource())
 storage_available(::CPURAMDevice, res::CPURAMResource) = storage_available(res)
 storage_available(::CPURAMDevice) = storage_available(CPURAMResource())
 storage_utilized(::CPURAMDevice, res::CPURAMResource) = storage_utilized(res)
 storage_utilized(::CPURAMDevice) = storage_utilized(CPURAMResource())
-function writetodevice!(device::CPURAMDevice, ref_id)
-    s = datastore[ref_id]
-    if !isinmemory(s)
-        sstate = s.file::StorageState
-        data = readfromdevice(sstate.device, ref_id, true)
-        s.data = Some{Any}(data)
+function write_to_device!(device::CPURAMDevice, state::RefState, ref_id::Int)
+    sstate = storage_read(state)
+    if sstate.data === nothing
+        data = read_from_device(first(sstate.leaves).device, state, ref_id, true)
+        notify(storage_rcu!(state) do sstate
+            StorageState(sstate; data=Some{Any}(data))
+        end)
     end
-    return ref_id
+    return
 end
-readfromdevice(::CPURAMDevice, ref_id, ret) = ret ? something(datastore[ref_id].data) : nothing
-function deletefromdevice!(::CPURAMDevice, ref_id)
-    datastore[ref_id].data = nothing
+function read_from_device(::CPURAMDevice, state::RefState, ref_id::Int, ret::Bool)
+    if ret
+        sstate = storage_read(state)
+        if sstate.data === nothing
+            # TODO: @assert !(sstate.leaf isa CPURAMDevice) "Data lost!"
+            return read_from_device(first(sstate.leaves).device, state, ref_id, true)
+        end
+        return something(sstate.data)
+    end
+end
+function delete_from_device!(::CPURAMDevice, state::RefState, ref_id::Int)
+    notify(storage_rcu!(state) do sstate
+        StorageState(sstate; data=nothing)
+    end)
+    return
 end
 
 """
     SerializationFileDevice <: StorageDevice
 
-Stores data in a temporary file, using the `Serialization` stdlib to write and
-read data.
+Stores data in a temporary file, using the `Serialization` stdlib to serialize
+and deserialize data. Also supports optional ser/des filtering stages, such as
+for compression or encryption.
 """
 struct SerializationFileDevice <: StorageDevice
     fs::FilesystemResource
     dir::String
+    filters::Vector{Pair}
 end
 "Construct a `SerializationFileDevice` which stores data in the directory `dir`."
-SerializationFileDevice(dir) =
-    SerializationFileDevice(FilesystemResource(Sys.iswindows() ? "C:" : "/"), dir)
-SerializationFileDevice() =
-    SerializationFileDevice(joinpath(tempdir(), ".mempool"))
+SerializationFileDevice(fs, dir; filters=Pair[]) =
+    SerializationFileDevice(fs, dir, filters)
+SerializationFileDevice(dir; filters=Pair[]) =
+    SerializationFileDevice(FilesystemResource(Sys.iswindows() ? "C:" : "/"), dir, filters)
+SerializationFileDevice(; filters=Pair[]) =
+    SerializationFileDevice(joinpath(tempdir(), ".mempool"); filters)
 storage_resources(dev::SerializationFileDevice) = Set{StorageResource}([dev.fs])
 function storage_capacity(dev::SerializationFileDevice, res::FilesystemResource)
-    @assert res == dev.fs
+    check_same_resource(dev, dev.fs, res)
     storage_capacity(res)
 end
 storage_capacity(dev::SerializationFileDevice) = storage_capacity(dev.fs)
 function storage_available(dev::SerializationFileDevice, res::FilesystemResource)
-    @assert res == dev.fs
+    check_same_resource(dev, dev.fs, res)
     storage_available(res)
 end
 storage_available(dev::SerializationFileDevice) = storage_available(dev.fs)
-function writetodevice!(device::SerializationFileDevice, ref_id)
+function storage_utilized(dev::SerializationFileDevice, res::FilesystemResource)
+    check_same_resource(dev, dev.fs, res)
+    return storage_capacity(dev, res) - storage_available(dev, res)
+end
+storage_utilized(dev::SerializationFileDevice) =
+    storage_capacity(dev, dev.fs) - storage_available(dev, dev.fs)
+function write_to_device!(device::SerializationFileDevice, state::RefState, ref_id::Int)
     mkpath(device.dir)
     path = tempname(device.dir; cleanup=false)
-    s = datastore[ref_id]
-    fref = FileRef(path, s.size)
-    open(path, "w") do io
-        serialize(io, MMWrap(something(s.data)))
+    fref = FileRef(path, state.size)
+    sstate = storage_read(state)
+    data = sstate.data
+    if data === nothing
+        data = read_from_device(first(sstate.leaves).device, state, ref_id, true)
+    else
+        data = something(data)
     end
-    _writetodevice!(ref_id, device, fref)
-    return ref_id
+    leaf = StorageLeaf(device)
+    sstate = storage_rcu!(state) do sstate
+        StorageState(sstate; leaves=vcat(sstate.leaves, leaf))
+    end
+    errormonitor(Threads.@spawn begin
+        open(path, "w") do io
+            for (write_filt, ) in reverse(device.filters)
+                io = write_filt(io)
+            end
+            serialize(io, MMWrap(data))
+            close(io)
+        end
+        leaf.handle = Some{Any}(fref)
+        notify(sstate)
+    end)
+    return
 end
-function readfromdevice(device::SerializationFileDevice, id, ret)
+function read_from_device(device::SerializationFileDevice, state::RefState, id::Int, ret::Bool)
+    sstate = storage_read(state)
+    data = sstate.data
+    if data !== nothing
+        ret && return something(data)
+        return
+    end
+    idx = findfirst(l->l.device === device, sstate.leaves)
+    fref = something(sstate.leaves[idx].handle)
+    sstate = storage_rcu!(state) do sstate
+        StorageState(sstate)
+    end
+    errormonitor(Threads.@spawn begin
+        data = open(fref.file, "r+") do io
+            for (_, read_filt) in reverse(device.filters)
+                io = read_filt(io)
+            end
+            unwrap_payload(deserialize(io))
+        end
+        sstate.data = Some{Any}(data)
+        notify(sstate)
+    end)
     if ret
-        datastore[id].data !== nothing && return
-        fref = storage_handle(id)
-        data = unwrap_payload(open(deserialize, fref.file, "r+"))
-        datastore[id].data = Some{Any}(data)
-        data
+        return something(sstate.data)
     end
 end
-function deletefromdevice!(device::SerializationFileDevice, id)
-    fref = storage_handle(id)
-    rm(fref.file; force=true)
-    datastore[id].file = nothing
-end
-
-struct StorageState
-    device::StorageDevice
-    handle
+function delete_from_device!(device::SerializationFileDevice, state::RefState, id::Int)
+    sstate = storage_read(state)
+    idx = findfirst(l->l.device === device, sstate.leaves)
+    idx === nothing && return
+    leaf = sstate.leaves[idx]
+    fref = something(leaf.handle)
+    notify(storage_rcu!(state) do sstate
+        StorageState(sstate; leaves=filter(l->l.device !== device,
+                                           sstate.leaves))
+    end)
+    if !leaf.retain
+        errormonitor(Threads.@spawn begin
+            rm(fref.file; force=true)
+        end)
+    end
+    return
 end
 
 """
-    LRUAllocator <: StorageDevice
+    SimpleRecencyAllocator <: StorageDevice
 
 A simple LRU allocator device which manages an `upper` device and a `lower`
 device. The `upper` device is be limited to `upper_limit` bytes of storage;
@@ -241,156 +577,256 @@ Consider using an `upper` device of `CPURAMDevice` and a `lower` device of
 device will be created and used automatically if the environment variable
 `JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR` is set to `1` or `true`.
 """
-struct LRUAllocator <: StorageDevice
+struct SimpleRecencyAllocator <: StorageDevice
     mem_limit::UInt64
     device::StorageDevice
     device_limit::UInt64
+    policy::Symbol
+
+    # Most recently used elements are always at the front
     mem_refs::Vector{Int}
     device_refs::Vector{Int}
-end
-LRUAllocator(mem_limit, device, device_limit) =
-    LRUAllocator(mem_limit, device, device_limit, Int[], Int[])
-storage_resources(lru::LRUAllocator) =
-    Set{StorageResource}([CPURAMResource(), lru.device])
-function storage_capacity(lru::LRUAllocator, res::StorageResource)
-    if res isa CPURAMResource
-        return lru.mem_limit
-    elseif res in storage_resources(lru.device)
-        return lru.device_limit
-    else
-        throw(ArgumentError("$res not contained in $lru"))
+
+    # Counters for Hit, Miss, Evict
+    stats::Vector{Int}
+
+    # Whether to retain all tracked refs
+    retain::Base.RefValue{Bool}
+
+    ref_cache::Dict{Int,RefState}
+    lock::NonReentrantLock
+
+    function SimpleRecencyAllocator(mem_limit, device, device_limit, policy; retain=false)
+        mem_limit > 0 || throw(ArgumentError("Memory limit must be positive and non-zero: $mem_limit"))
+        device_limit > 0 || throw(ArgumentError("Device limit must be positive and non-zero: $device_limit"))
+        policy in (:LRU, :MRU) || throw(ArgumentError("Invalid recency policy: $policy"))
+        return new(mem_limit, device, device_limit, policy,
+                   Int[], Int[], zeros(Int, 3), Ref(retain),
+                   Dict{Int,RefState}(), NonReentrantLock())
     end
 end
-storage_capacity(lru::LRUAllocator) = lru.mem_limit + lru.device_limit
-storage_available(lru::LRUAllocator, res::StorageResource) =
-    storage_capacity(lru, res) - storage_utilized(lru, res)
-storage_available(lru::LRUAllocator) =
-    storage_capacity(lru) - storage_utilized(lru)
-function storage_utilized(lru::LRUAllocator, res::StorageResource)
+
+function Base.show(io::IO, sra::SimpleRecencyAllocator)
+    mem_res = CPURAMResource()
+    mem_used = Base.format_bytes(storage_utilized(sra, mem_res))
+    device_used = 0
+    for res in storage_resources(sra.device)
+        device_used += storage_utilized(sra, res)
+    end
+    device_used = Base.format_bytes(device_used)
+    mem_limit = Base.format_bytes(sra.mem_limit)
+    device_limit = Base.format_bytes(sra.device_limit)
+    println(io, "SimpleRecencyAllocator(mem: $mem_used used ($mem_limit max), device: $device_used used ($device_limit max), policy: $(sra.policy))")
+    print(io, "  Stats: $(sra.stats[1]) Hits, $(sra.stats[2]) Misses, $(sra.stats[3]) Evicts")
+end
+
+storage_resources(sra::SimpleRecencyAllocator) =
+    Set{StorageResource}([CPURAMResource(), storage_resources(sra.device)...])
+function storage_capacity(sra::SimpleRecencyAllocator, res::StorageResource)
     if res isa CPURAMResource
-        return sum(map(storage_size, lru.mem_refs))
-    elseif res in storage_resources(lru.device)
-        return sum(map(storage_size, lru.device_refs))
+        return sra.mem_limit
+    elseif res in storage_resources(sra.device)
+        return sra.device_limit
     else
-        throw(ArgumentError("$res not contained in $lru"))
+        throw(ArgumentError("Invalid storage resource $res for device $sra"))
     end
 end
-storage_utilized(lru::LRUAllocator) =
-    sum(map(storage_size, lru.mem_refs)) +
-    sum(map(storage_size, lru.device_refs))
-function writetodevice!(lru::LRUAllocator, ref_id)
-    ref_state = datastore[ref_id]
-    if ref_state.size > lru.mem_limit
-        # Won't fit in memory, can we demote?
-        if ref_state.size > lru.device_limit
-            # Too bulky, won't fit in device either
-            throw(ArgumentError("DRef data for ID $ref_id too large!"))
+storage_capacity(sra::SimpleRecencyAllocator) = sra.mem_limit + sra.device_limit
+storage_available(sra::SimpleRecencyAllocator, res::StorageResource) =
+    storage_capacity(sra, res) - storage_utilized(sra, res)
+storage_available(sra::SimpleRecencyAllocator) =
+    storage_capacity(sra) - storage_utilized(sra)
+function storage_utilized(sra::SimpleRecencyAllocator, res::StorageResource)
+    if res isa CPURAMResource
+        return with_lock(sra.lock) do
+            sum(map(id->sra.ref_cache[id].size, sra.mem_refs))
         end
-        # Demote to device immediately
-        lru_migrate!(lru, ref_id, false)
-        deletefromdevice!(CPURAMDevice(), ref_id)
-        @assert ref_state.file !== nothing
-        return
+    elseif res in storage_resources(sra.device)
+        return with_lock(sra.lock) do
+            sum(map(id->sra.ref_cache[id].size, sra.device_refs))
+        end
+    else
+        throw(ArgumentError("Invalid storage resource $res for device $sra"))
     end
-    lru_migrate!(lru, ref_id, true)
 end
-function lru_migrate!(lru::LRUAllocator, ref_id, to_mem)
-    ref_size = datastore[ref_id].size
+storage_utilized(sra::SimpleRecencyAllocator) = with_lock(sra.lock) do
+    sum(map(id->sra.ref_cache[id].size, sra.mem_refs)) +
+    sum(map(id->sra.ref_cache[id].size, sra.device_refs))
+end
+function write_to_device!(sra::SimpleRecencyAllocator, state::RefState, ref_id::Int)
+    with_lock(sra.lock) do
+        sra.ref_cache[ref_id] = state
+    end
+    try
+        if state.size > sra.mem_limit || state.size > sra.device_limit
+            # Too bulky
+            throw(ArgumentError("Cannot write ref $ref_id of size $(Base.format_bytes(state.size)) to LRU"))
+        end
+        sra_migrate!(sra, state, ref_id, true)
+    catch err
+        delete!(sra.ref_cache, ref_id)
+        rethrow(err)
+    end
+    return
+end
+function sra_migrate!(sra::SimpleRecencyAllocator, state::RefState, ref_id, to_mem;
+                      read=false, locked=false)
+    ref_size = state.size
     if to_mem
         # Demoting to device
-        from_refs = lru.mem_refs
-        from_limit = lru.mem_limit
+        from_refs = sra.mem_refs
+        from_limit = sra.mem_limit
         from_device = CPURAMDevice()
-        to_refs = lru.device_refs
-        to_limit = lru.device_limit
-        to_device = lru.device
+        to_refs = sra.device_refs
+        to_limit = sra.device_limit
+        to_device = sra.device
     else
         # Promoting to memory
-        from_refs = lru.device_refs
-        from_limit = lru.device_limit
-        from_device = lru.device
-        to_refs = lru.mem_refs
-        to_limit = lru.mem_limit
+        from_refs = sra.device_refs
+        from_limit = sra.device_limit
+        from_device = sra.device
+        to_refs = sra.mem_refs
+        to_limit = sra.mem_limit
         to_device = CPURAMDevice()
     end
-    from_size = sum(map(x->datastore[x].size, from_refs))
-    to_size = sum(map(x->datastore[x].size, to_refs))
-    idx = to_mem ? lastindex(from_refs) : firstindex(from_refs)
-    # TODO: Plan migrations to determine feasibility
-    while ref_size + from_size > from_limit
-        # Demote older/promote newer refs until space is available
-        @assert 1 <= idx <= length(from_refs) "Failed to make $ref_size bytes of space available"
-        oref = from_refs[idx]
-        oref_size = datastore[oref].size
-        if oref_size + to_size <= to_limit
-            # Destination has space for this ref
-            readfromdevice(from_device, oref, true)
-            # N.B. We `writetodevice!` before deleting from old device, in case
-            # the write fails (so we don't lose data)
-            if to_mem
-                writetodevice!(to_device, oref)
-            end
-            push!(to_refs, oref)
-            deletefromdevice!(from_device, oref)
-            deleteat!(from_refs, idx)
-            @assert something(datastore[oref].data, datastore[oref].file) !== nothing
-            from_size -= oref_size
-            to_size += oref_size
+    from_size = 0
+    to_size = 0
+    idx = 0
+    with_lock(sra.lock, !locked) do
+        from_size = sum(map(id->sra.ref_cache[id].size, from_refs))
+        to_size = sum(map(id->sra.ref_cache[id].size, to_refs))
+        idx = if sra.policy == :LRU
+            to_mem ? lastindex(from_refs) : firstindex(from_refs)
+        else
+            to_mem ? firstindex(from_refs) : lastindex(from_refs)
         end
-        idx += to_mem ? -1 : 1
-    end
 
-    # Space available, perform migration
-    readfromdevice(ref_id)
-    writetodevice!(from_device, ref_id)
-    pushfirst!(from_refs, ref_id)
-    if (idx = findfirst(x->x==ref_id, to_refs)) !== nothing
-        deletefromdevice!(to_device, ref_id)
-        deleteat!(to_refs, idx)
-        @assert something(datastore[ref_id].data, datastore[ref_id].file) !== nothing
-    end
-end
-function readfromdevice(lru::LRUAllocator, id, ret)
-    if (idx = findfirst(x->x==id, lru.mem_refs)) !== nothing
-        deleteat!(lru.mem_refs, idx)
-        pushfirst!(lru.mem_refs, id)
-        readfromdevice(CPURAMDevice(), id, ret)
-    else
-        idx = findfirst(x->x==id, lru.device_refs)
-        @assert idx !== nothing
-        lru_migrate!(lru, id, true)
-        device = storage_device(id)
-        readfromdevice(device, id, ret)
-    end
-end
-function deletefromdevice!(lru::LRUAllocator, id)
-    if (idx = findfirst(x->x==id, lru.mem_refs)) !== nothing
-        deletefromdevice!(CPURAMDevice(), lru.mem_refs[idx])
-        deleteat!(lru.mem_refs, idx)
-    else
-        idx = findfirst(x->x==id, lru.device_refs)
-        @assert idx !== nothing
-        deletefromdevice!(lru.device, lru.device_refs[idx])
-        deleteat!(lru.device_refs, idx)
-    end
-end
-externally_varying(::LRUAllocator) = false
+        # Plan a batch of writes
+        write_list = Int[]
+        while ref_size + from_size > from_limit
+            # Demote older/promote newer refs until space is available
+            @assert 1 <= idx <= length(from_refs) "Failed to migrate $(Base.format_bytes(ref_size)) for ref $ref_id"
+            oref = from_refs[idx]
+            oref_size = sra.ref_cache[oref].size
+            if oref_size + to_size <= to_limit
+                # Destination has space for this ref
+                push!(write_list, idx)
+                from_size -= oref_size
+                to_size += oref_size
+            end
+            idx += (to_mem ? -1 : 1) * (sra.policy == :LRU ? 1 : -1)
+        end
+        if isempty(write_list)
+            @goto write_ref
+        end
 
-function setdevice!(device::StorageDevice, id)
-    old_device = device_map[id]
-    old_device == device && return
-    readfromdevice(device, id, true)
-    writetodevice!(device, id)
-    deletefromdevice!(old_device, id)
-    device_map[id] = device
-end
-function setdevice!(device::StorageDevice, ref::DRef)
-    if ref.owner == myid()
-        setdevice!(device, ref.id)
-    else
-        remotecall_wait(setdevice!, ref.owner, ref.id)
+        # Initiate writes
+        @sync for idx in write_list
+            @inbounds sra.stats[3] += 1
+            oref = from_refs[idx]
+            oref_state = sra.ref_cache[oref]
+            # N.B. We `write_to_device!` before deleting from old device, in case
+            # the write fails (so we don't lose data)
+            write_to_device!(to_device, oref_state, oref)
+            @async delete_from_device!(from_device, oref_state, oref)
+            @assert begin
+                sstate = storage_read(oref_state)
+                sstate.data !== nothing || any(l->l.handle !== nothing, sstate.leaves)
+            end
+        end
+
+        # Update counters
+        for oref in map(idx->from_refs[idx], write_list)
+            push!(to_refs, oref)
+            deleteat!(from_refs, findfirst(==(oref), from_refs))
+        end
+
+        # Space available, perform migration
+        @label write_ref
+        pushfirst!(from_refs, ref_id)
+        write_to_device!(from_device, state, ref_id)
+
+        # If we already had this ref, delete it from previous device
+        if findfirst(x->x==ref_id, to_refs) !== nothing
+            delete_from_device!(to_device, state, ref_id)
+            deleteat!(to_refs, findfirst(x->x==ref_id, to_refs))
+        end
+
+        if read
+            return read_from_device(from_device, state, ref_id, true)
+        end
     end
+end
+function read_from_device(sra::SimpleRecencyAllocator, state::RefState, id::Int, ret::Bool)
+    with_lock(sra.lock) do
+        idx = findfirst(x->x==id, sra.mem_refs)
+        if idx !== nothing
+            @inbounds sra.stats[1] += 1
+            deleteat!(sra.mem_refs, idx)
+            pushfirst!(sra.mem_refs, id)
+            return read_from_device(CPURAMDevice(), state, id, ret)
+        end
+        @assert id in sra.device_refs
+        @inbounds sra.stats[2] += 1
+        value = sra_migrate!(sra, state, id, true; read=true, locked=true)
+        if ret
+            return value
+        end
+    end
+end
+function delete_from_device!(sra::SimpleRecencyAllocator, state::RefState, id::Int)
+    with_lock(sra.lock) do
+        if (idx = findfirst(x->x==id, sra.mem_refs)) !== nothing
+            if sra.retain[]
+                # Migrate to device for retention
+                sra_migrate!(sra, state, id, false; read=false, locked=true)
+            else
+                delete_from_device!(CPURAMDevice(), state, id)
+                deleteat!(sra.mem_refs, idx)
+                delete!(sra.ref_cache, id)
+                return
+            end
+        end
+        if (idx = findfirst(x->x==id, sra.device_refs)) !== nothing
+            if sra.retain[]
+                retain_on_device!(sra.device, state, sra.device_refs[idx], true)
+            end
+            delete_from_device!(sra.device, state, sra.device_refs[idx])
+            deleteat!(sra.device_refs, idx)
+            delete!(sra.ref_cache, id)
+        end
+    end
+    return
+end
+function retain_on_device!(sra::SimpleRecencyAllocator, retain::Bool)
+    with_lock(sra.lock) do
+        # Retention will happen lazily, upon deletion
+        sra.retain[] = retain
+    end
+end
+externally_varying(::SimpleRecencyAllocator) = false
+
+function set_device!(device::StorageDevice, state::RefState, id::Int)
+    sstate = storage_read(state)
+    old_device = sstate.root
+    if old_device === device && findfirst(l->l.device === device, sstate.leaves) !== nothing
+        return
+    end
+    write_to_device!(device, state, id)
+    notify(storage_rcu!(state) do sstate
+        StorageState(sstate; root=device)
+    end)
+    return
+end
+set_device!(device::StorageDevice, id::Int) =
+    set_device!(device, with_lock(()->datastore[id], datastore_lock), id)
+function set_device!(device::StorageDevice, ref::DRef)
+    @assert ref.owner == myid()
+    set_device!(device, ref.id)
+end
+function set_device!(device::StorageDevice, state::RefState, ref::DRef)
+    @assert ref.owner == myid()
+    set_device!(device, state, ref.id)
 end
 
 const GLOBAL_DEVICE = Ref{StorageDevice}(CPURAMDevice())
-const device_map = Dict{Int,StorageDevice}()

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -41,14 +41,8 @@ storage_capacity(::CPURAMResource) = Sys.total_memory()
 struct FilesystemResource <: StorageResource
     mountpoint::String
 end
-function storage_available(s::FilesystemResource)
-    vfs = statvfs(s.mountpoint)
-    return vfs.f_bavail * vfs.f_bsize
-end
-function storage_capacity(s::FilesystemResource)
-    vfs = statvfs(s.mountpoint)
-    return vfs.f_blocks * vfs.f_bsize
-end
+storage_available(s::FilesystemResource) = disk_stats(s.mountpoint).available
+storage_capacity(s::FilesystemResource) = disk_stats(s.mountpoint).capacity
 
 """
     StorageDevice

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-StaticArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,18 @@
 include("testenv.jl")
 
-ENV["JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR"] = "0"
-
 if nprocs() == 1
     addprocs_with_testenv(2)
 end
+
+@everywhere ENV["JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR"] = "0"
 
 using Serialization, Random
 
 @everywhere using Sockets
 
 @everywhere using MemPool
+import MemPool: CPURAMDevice, SerializationFileDevice, SimpleRecencyAllocator
+import MemPool: storage_read
 using Test
 
 import Sockets: getipaddr
@@ -69,15 +71,17 @@ end
     @test !isassigned(sa2, 2)
 end
 
-@testset "approx_size $(typeof(x))" for x in (
-    "foo~^å&",
-    SubString("aaaaa", 2),
-)
-    @test MemPool.approx_size(x) == Base.summarysize(x)
-end
-@testset "approx_size Symbol" begin
-    s = Symbol("foo~^å&")
-    @test MemPool.approx_size(s) == Base.summarysize(String(s))
+@testset "approx_size" begin
+    @testset "approx_size $(typeof(x))" for x in (
+        "foo~^å&",
+        SubString("aaaaa", 2),
+    )
+        @test MemPool.approx_size(x) == Base.summarysize(x)
+    end
+    @testset "approx_size Symbol" begin
+        s = Symbol("foo~^å&")
+        @test MemPool.approx_size(s) == Base.summarysize(String(s))
+    end
 end
 
 
@@ -96,38 +100,9 @@ end
     @test MemPool.fixedlength(Union{Nothing,Vector{Int}}) == -1 # Issue #43.
 end
 
-#=
-@testset "lru" begin
-    # clean up
-    tmpsz = MemPool.max_memsize[]
-    MemPool.max_memsize[] = 20
-    empty!(MemPool.lru_order)
-
-    @test isempty(lru_evictable(20))
-    lru_touch(1, 10)
-    @test isempty(lru_evictable(10))
-    @test lru_evictable(11) == [1]
-    lru_touch(2, 10)
-    @test isempty(lru_evictable(0))
-    @test lru_evictable(1) == [1]
-    @test lru_evictable(10) == [1]
-    @test lru_evictable(11) == [1,2]
-    lru_touch(1, 10)
-    @test lru_evictable(1) == [2]
-    @test lru_evictable(10) == [2]
-    @test lru_evictable(11) == [2,1]
-
-    MemPool.max_memsize[] = tmpsz
-    empty!(MemPool.lru_order)
-end
-=#
-
 @testset "DRef equality" begin
     d1 = poolset(1)
-    iob = IOBuffer()
-    serialize(iob, d1)
-    seek(iob, 0)
-    d2 = deserialize(iob)
+    d2 = copy(d1)
     @test d1 == d2
     @test hash(d1) == hash(d2)
 
@@ -136,52 +111,144 @@ end
     @test haskey(d, d1)
     @test haskey(d, d2)
     @test d[d2] == 1
-
-    pooldelete(d1)
 end
 
-@testset "set-get-delete" begin
+@testset "Set-Get" begin
     r1 = poolset([1,2])
     r2 = poolset(["abc","def"], 2)
     r3 = poolset([Ref(1),Ref(2)], 2)
     @test poolget(r1) == [1,2]
     @test poolget(r2) == ["abc","def"]
     @test map(getindex, poolget(r3)) == [1,2]
-    pooldelete(r1)
-    @test_throws KeyError poolget(r1)
-    pooldelete(r2)
-    pooldelete(r3)
-    @test_throws KeyError poolget(r2)
-    #@test isempty(MemPool.lru_order)
-    #@test fetch(@spawnat 2 isempty(MemPool.lru_order))
-    @test isempty(MemPool.datastore)
-    #@test fetch(@spawnat 2 isempty(MemPool.datastore))
 end
 
-@testset "refcounting" begin
-    r1 = poolset([1,2],2)
-    key = (r1.owner,r1.id)
-    @test MemPool.local_datastore_counter[key][] == 1
-    @test !haskey(MemPool.datastore_counter, key)
-    @spawnat 2 GC.gc()
-    @test fetch(@spawnat 2 MemPool.datastore_counter[key][]) == 1
-    poolref(r1)
-    @test MemPool.local_datastore_counter[key][] == 2
-    @test fetch(@spawnat 2 MemPool.datastore_counter[key][]) == 1
-    poolunref(r1)
-    @test MemPool.local_datastore_counter[key][] == 1
-    poolunref(r1)
-    @test !haskey(MemPool.local_datastore_counter, key)
-    sleep(1) # allow poolunref_owner to initiate on remote
-    @spawnat 2 GC.gc() # force owner to call finalizer
-    @test fetch(@spawnat 2 !haskey(MemPool.datastore_counter, key))
-    @test_throws KeyError poolget(r1)
-    @test_throws AssertionError poolunref(r1)
-    poolref(r1) # Necessary since we actually still hold a reference
+@testset "Distributed reference counting" begin
+    @testset "Owned locally" begin
+        # Owned by us
+        r1 = poolset([1,2])
+        key1 = (r1.owner, r1.id)
+        id1 = r1.id
+
+        # We know about this DRef
+        @test haskey(MemPool.datastore_counters, key1)
+        # We own it, and are told when others receive it, but it hasn't been passed around yet
+        @test MemPool.datastore_counters[key1].worker_counter[] == 1
+        @test length(MemPool.datastore_counters[key1].recv_counters) == 0
+        # We hold a local reference to it
+        @test MemPool.datastore_counters[key1].local_counter[] == 1
+        # We haven't sent it to anyone
+        @test length(MemPool.datastore_counters[key1].send_counters) == 0
+
+        # They don't know about it
+        @test fetch(@spawnat 2 !haskey(MemPool.datastore_counters, key1))
+
+        # Send them a copy
+        @everywhere [2] begin
+            # They know about this DRef
+            @assert haskey(MemPool.datastore_counters, $key1)
+            # They don't own it, and aren't told when others receive it
+            @assert MemPool.datastore_counters[$key1].worker_counter[] == 0
+            @assert length(MemPool.datastore_counters[$key1].recv_counters) == 0
+            # They hold a local reference to it
+            @assert MemPool.datastore_counters[$key1].local_counter[] == 1
+            # They haven't sent it to anyone
+            @assert length(MemPool.datastore_counters[$key1].send_counters) == 0
+            # Here to ensure r1 is serialized and retained
+            const r1_ref = Ref{Any}($r1)
+        end
+
+        # We've sent it to them and are tracking that
+        @test MemPool.datastore_counters[key1].worker_counter[] == 2
+
+        # Delete their copy
+        @everywhere [2] begin
+            r1_ref[] = nothing
+            GC.gc(); sleep(0.5)
+        end
+        GC.gc(); sleep(0.5)
+
+        # They don't know about it (anymore)
+        @test fetch(@spawnat 2 !haskey(MemPool.datastore_counters, key1))
+
+        # They're done with it and we're aware of that
+        @test MemPool.datastore_counters[key1].worker_counter[] == 1
+    end
+
+    @testset "Owned remotely" begin
+        # Owned by worker 2 ("them")
+        r2 = poolset([1,2], 2)
+        key2 = (r2.owner, r2.id)
+        id2 = r2.id
+
+        # Give us some time to tell them we received r2
+        @everywhere GC.gc()
+        sleep(1)
+
+        # We know about this DRef
+        @test haskey(MemPool.datastore_counters, key2)
+        # We don't own it, and aren't told when others receive it
+        @test MemPool.datastore_counters[key2].worker_counter[] == 0
+        @test length(MemPool.datastore_counters[key2].recv_counters) == 0
+        # We hold a local reference to it
+        @test MemPool.datastore_counters[key2].local_counter[] == 1
+        # We haven't sent it to anyone (yet)
+        @test length(MemPool.datastore_counters[key2].send_counters) == 0
+
+        @everywhere [2] begin
+            # They know about this DRef
+            @assert haskey(MemPool.datastore_counters, $key2)
+            # They own it, and are told when others receive it (and we have received it, but they're already aware of that)
+            @assert MemPool.datastore_counters[$key2].worker_counter[] == 1
+            @assert length(MemPool.datastore_counters[$key2].recv_counters) == 0
+            # They don't hold a local reference to it
+            @assert MemPool.datastore_counters[$key2].local_counter[] == 0
+            # They haven't sent it to anyone (recently)
+            @assert length(MemPool.datastore_counters[$key2].send_counters) == 0
+        end
+
+        # Send them a copy
+        @everywhere [2] begin
+            const r2_ref = Ref{Any}($r2)
+            # They hold a local reference to it
+            @assert MemPool.datastore_counters[$key2].local_counter[] == 1
+            # They know about our and their copies
+            @assert MemPool.datastore_counters[$key2].worker_counter[] == 2
+        end
+
+        # Delete our copy
+        r2 = nothing
+        @everywhere GC.gc()
+        sleep(0.5)
+        # We don't know about this DRef (anymore)
+        @test_broken !haskey(MemPool.datastore_counters, key2)
+
+        @test_skip "They only see their copy"
+        #=
+        @everywhere [2] begin
+            # They only see their copy
+            @assert MemPool.datastore_counters[$key2].worker_counter[] == 1
+        end
+        =#
+
+        # Delete their copy
+        @everywhere [2] begin
+            r2_ref[] = nothing
+            GC.gc(); sleep(0.5)
+        end
+
+        @test_skip "They don't know about this DRef (anymore)"
+        #=
+        @everywhere [2] begin
+            # They don't know about this DRef (anymore)
+            @assert !haskey(MemPool.datastore_counters, $key2)
+        end
+        =#
+    end
 end
 
 @testset "movetodisk" begin
     ref = poolset([1,2], 2)
+    ref_id = ref.id
     fref = movetodisk(ref)
     @test isa(fref, MemPool.FileRef)
     @test fref.host == getipaddr()
@@ -190,13 +257,12 @@ end
     fref2 = savetodisk(ref, f)
     @test fref2.file == f
     @test poolget(fref) == poolget(fref2)
-    pooldelete(ref)
-    @test fetch(@spawnat 2 isempty(MemPool.datastore))
+    ref = nothing; @everywhere GC.gc(); sleep(1)
+    @test fetch(@spawnat 2 !haskey(MemPool.datastore, ref_id))
 
     ref = poolset([1,2], 2)
     fref = movetodisk(ref)
     @test remotecall_fetch(poolget, 2, fref) == poolget(ref)
-    @everywhere (using MemPool; MemPool.cleanup())
 
     @test MemPool.get_worker_at(getipaddr()) in [1,2,3]
     @test remotecall_fetch(()->MemPool.get_worker_at(getipaddr()), 2) in [1,2,3]
@@ -205,128 +271,544 @@ end
     @test MemPool.is_my_ip(getipaddr())
 end
 
+@testset "StorageState" begin
+    sstate1 = MemPool.StorageState(nothing,
+                                   MemPool.StorageLeaf[],
+                                   CPURAMDevice())
+    @test sstate1 isa MemPool.StorageState
+    @test sstate1.ready isa Base.Event
+    @test !sstate1.ready.set
+    notify(sstate1)
+    @test sstate1.ready.set
+    @test sstate1.root isa CPURAMDevice
+    @test length(sstate1.leaves) == 0
+    @test sstate1.data === nothing
+    @test sstate1 === sstate1
+
+    sstate2 = MemPool.StorageState(sstate1; data=Some{Any}(123))
+    @test sstate2 !== sstate1
+    @test sstate2.ready !== sstate1.ready
+    @test !sstate2.ready.set
+    notify(sstate2)
+    @test sstate2.root isa CPURAMDevice
+    @test length(sstate2.leaves) == 0
+    @test sstate2.data isa Some{Any}
+    @test something(sstate2.data) == 123
+
+    x1 = poolset([1,2,3])
+    @test MemPool.isinmemory(x1)
+    state = MemPool.datastore[x1.id]
+    sstate = MemPool.storage_read(state)
+    @test sstate === MemPool.storage_read(state)
+    wait(sstate)
+    @test sstate.ready.set
+    @test length(sstate.leaves) == 0
+    @test sstate.root isa CPURAMDevice
+    @test sstate.data isa Some{Any}
+    @test something(sstate.data) == [1,2,3]
+
+    sdevice = MemPool.SerializationFileDevice(joinpath(MemPool.default_dir(), randstring(6)))
+    MemPool.set_device!(sdevice, x1)
+    @test MemPool.isondisk(x1)
+    @test MemPool.datastore[x1.id] === state
+    new_sstate = MemPool.storage_read(state)
+    @test sstate !== new_sstate
+    wait(new_sstate)
+    @test new_sstate.ready.set
+    @test new_sstate.root === sdevice
+    @test new_sstate.data isa Some{Any}
+    @test length(new_sstate.leaves) == 1
+    leaf = first(new_sstate.leaves)
+    @test leaf.device === sdevice
+    @test leaf.handle isa Some{Any}
+    @test something(leaf.handle) isa FileRef
+end
+
+@testset "RefState" begin
+    sstate1 = MemPool.StorageState(Some{Any}(123),
+                                   MemPool.StorageLeaf[],
+                                   CPURAMDevice(),
+                                   Base.Event())
+    notify(sstate1)
+    state = MemPool.RefState(sstate1, 64)
+    @test state.size == 64
+    @test MemPool.storage_size(state) == 64
+    @test_throws ArgumentError state.storage
+    sstate2 = MemPool.storage_read(state)
+    @test sstate2 isa MemPool.StorageState
+    @test sstate2 === sstate1
+
+    @test_throws ArgumentError (state.storage = sstate1)
+    sstate3 = MemPool.storage_rcu!(state) do old_sstate
+        @test old_sstate === sstate1
+        # N.B. Not semantically correct to have CPURAMDevice as leaf
+        leaf = MemPool.StorageLeaf(CPURAMDevice(), Some{Any}(456))
+        MemPool.StorageState(old_sstate; leaves=[leaf])
+    end
+    @test !sstate3.ready.set
+    notify(sstate3)
+    @test sstate3 !== sstate1
+    @test sstate3.data isa Some{Any}
+    @test something(sstate3.data) == 123
+    @test length(sstate3.leaves) == 1
+    leaf = first(sstate3.leaves)
+    @test leaf.device isa CPURAMDevice
+    @test leaf.handle isa Some{Any}
+    @test something(leaf.handle) == 456
+
+    @test_throws ConcurrencyViolationError MemPool.storage_rcu!(old_sstate->old_sstate, state)
+end
+
+@testset "CPURAMDevice" begin
+    # Delete -> read throws
+    x = poolset(123)
+    MemPool.delete_from_device!(CPURAMDevice(), x)
+    @test_throws Exception poolget(x)
+end
+
 @testset "SerializationFileDevice" begin
     x1 = poolset([1,2,3])
     state = MemPool.datastore[x1.id]
-    data = something(state.data)
+    data = something(storage_read(state).data)
 
-    sdevice = MemPool.SerializationFileDevice("testdata")
-    MemPool.setdevice!(sdevice, x1.id)
-    @test state.file !== nothing
-    sstate = state.file
-    @test sstate.device == sdevice
-    @test sstate.handle isa FileRef
-    path = sstate.handle.file
-    @test isdir("testdata")
+    dirpath = mktempdir()
+    sdevice = MemPool.SerializationFileDevice(dirpath)
+    MemPool.set_device!(sdevice, x1.id)
+    sstate = MemPool.storage_read(state)
+    leaf = first(sstate.leaves)
+    @test sstate.root === leaf.device === sdevice
+    @test leaf.handle !== nothing
+    @test something(leaf.handle) isa FileRef
+    path = something(leaf.handle).file
+    @test isdir(dirpath)
     @test isfile(path)
+    @test normpath(joinpath(dirpath, basename(path))) == normpath(path)
     @test poolget(x1) == data
-    @test state.file !== nothing
+    # Retains the FileRef after read to memory
+    @test first(storage_read(state).leaves).handle !== nothing
 
-    MemPool.deletefromdevice!(MemPool.CPURAMDevice(), x1.id)
-    @test state.data === nothing
+    MemPool.delete_from_device!(CPURAMDevice(), state, x1.id)
+    @test storage_read(state).data === nothing
     @test poolget(x1) == data
-    @test state.data !== nothing
+    @test storage_read(state).data !== nothing
+    MemPool.delete_from_device!(sdevice, state, x1)
+    @test length(storage_read(state).leaves) == 0
 
-    MemPool.setdevice!(MemPool.CPURAMDevice(), x1)
+    # With retention, data is retained
+    MemPool.set_device!(sdevice, state, x1)
+    MemPool.retain_on_device!(sdevice, state, x1, true)
+    sstate = storage_read(state)
+    @test only(sstate.leaves).retain
+    path = something(only(sstate.leaves).handle).file
+    MemPool.delete_from_device!(sdevice, state, x1)
+    @test length(storage_read(state).leaves) == 0
+    GC.gc(); sleep(1)
+    # File is retained
+    @test isfile(path)
+    # Retention cannot be changed after deletion
+    @test_throws ArgumentError MemPool.retain_on_device!(sdevice, state, x1, false)
+    # Memory is retained
+    @test storage_read(state).data !== nothing
+    @test poolget(x1) == data
+
+    # Without retention, data is lost
+    MemPool.set_device!(sdevice, state, x1)
+    MemPool.retain_on_device!(sdevice, state, x1, false)
+    sstate = storage_read(state)
+    @test !only(sstate.leaves).retain
+    path = something(only(sstate.leaves).handle).file
+    MemPool.delete_from_device!(sdevice, state, x1)
+    @test length(storage_read(state).leaves) == 0
+    GC.gc(); sleep(1)
+    # File is not retained
     @test !isfile(path)
-    @test state.data !== nothing
+    # Retention cannot be changed after deletion
+    @test_throws ArgumentError MemPool.retain_on_device!(sdevice, state, x1, true)
+    # Memory is retained
+    @test storage_read(state).data !== nothing
     @test poolget(x1) == data
 
-    rm("testdata"; recursive=true)
+    @testset "Serialization Filters" begin
+        struct BitOpSerializer{O,I} <: IO
+            io::IO
+            value::UInt8
+            out_op::O
+            in_op::I
+        end
+        BitOpSerializer(io::IO, value::UInt8, op) = BitOpSerializer(io, value, op, op)
+        Base.write(io::BitOpSerializer, x::UInt8) = write(io.io, io.out_op(x, io.value))
+        Base.read(io::BitOpSerializer, ::Type{UInt8}) = io.in_op(read(io.io, UInt8), io.value)
+        Base.close(io::BitOpSerializer) = close(io.io)
+        Base.eof(io::BitOpSerializer) = eof(io.io)
+
+        # Symmetric filtering
+        sdevice2 = SerializationFileDevice()
+        push!(sdevice2.filters, (io->BitOpSerializer(io, 0x42, ⊻))=>(io->BitOpSerializer(io, 0x42, ⊻)))
+        x1 = poolset(UInt8(123); device=sdevice2)
+        MemPool.delete_from_device!(CPURAMDevice(), x1)
+        path = something(only(storage_read(MemPool.datastore[x1.id]).leaves).handle).file
+        # Filter is applied on-disk
+        iob = IOBuffer(); serialize(iob, UInt8(123)); seek(iob, 0)
+        @test read(path, UInt8) == first(take!(iob)) ⊻ 0x42
+        # Filter is undone on read
+        @test poolget(x1) == UInt8(123)
+
+        # Asymmetric filtering
+        sdevice2 = SerializationFileDevice()
+        push!(sdevice2.filters, (io->BitOpSerializer(io, 0x42, +, -))=>(io->BitOpSerializer(io, 0x42, +, -)))
+        x1 = poolset(UInt8(123); device=sdevice2)
+        MemPool.delete_from_device!(CPURAMDevice(), x1)
+        path = something(only(storage_read(MemPool.datastore[x1.id]).leaves).handle).file
+        # Filter is applied on-disk before serialization
+        iob = IOBuffer(); serialize(iob, UInt8(123)); seek(iob, 0)
+        @test read(path, UInt8) == first(take!(iob)) + 0x42
+        # Filter is undone on read
+        @test poolget(x1) == UInt8(123)
+
+        # Chained filtering
+        sdevice2 = SerializationFileDevice()
+        push!(sdevice2.filters, (io->BitOpSerializer(io, 0x3, +, -))=>(io->BitOpSerializer(io, 0x3, +, -)))
+        push!(sdevice2.filters, (io->BitOpSerializer(io, 0x5, ⊻))=>(io->BitOpSerializer(io, 0x5, ⊻)))
+        x1 = poolset(UInt8(123); device=sdevice2)
+        MemPool.delete_from_device!(CPURAMDevice(), x1)
+        path = something(only(storage_read(MemPool.datastore[x1.id]).leaves).handle).file
+        # Filter is applied on-disk before serialization
+        iob = IOBuffer(); serialize(iob, UInt8(123)); seek(iob, 0)
+        value = first(take!(iob))
+        @test read(path, UInt8) == (value + 0x3) ⊻ 0x5
+        @test read(path, UInt8) != (value ⊻ 0x5) + 0x3
+        # Filter is undone on read
+        @test poolget(x1) == UInt8(123)
+    end
 end
 
-inmem(ref) = remotecall_fetch(id -> MemPool.isinmemory(MemPool.datastore[id]), ref.owner, ref.id)
-lru_upper_refs(owner) = remotecall_fetch(() -> MemPool.GLOBAL_DEVICE[].mem_refs, owner)
-lru_lower_refs(owner) = remotecall_fetch(() -> MemPool.GLOBAL_DEVICE[].device_refs, owner)
-lru_upper_pos(ref) = findfirst(x->x==ref.id, lru_upper_refs(ref.owner))
-lru_lower_pos(ref) = findfirst(x->x==ref.id, lru_lower_refs(ref.owner))
-@testset "LRUAllocator" begin
-    old_alloc = MemPool.GLOBAL_DEVICE[]
-    alloc = MemPool.LRUAllocator(8*10,
-                                 MemPool.SerializationFileDevice(MemPool.default_dir(myid())), 8*10_000)
-    @everywhere MemPool.GLOBAL_DEVICE[] = $alloc
-    r1 = poolset([1,2], 2)
-    r2 = poolset([1,2,3], 2)
-    r3 = poolset([1,2,3,4,5], 2)
+sra_upper_pos(sra, ref) = findfirst(x->x==ref.id, sra.mem_refs)
+sra_lower_pos(sra, ref) = findfirst(x->x==ref.id, sra.device_refs)
+sra_inmem_pos(sra, ref, idx) =
+    MemPool.isinmemory(ref) &&
+    !MemPool.isondisk(ref) &&
+    sra_upper_pos(sra, ref) == idx &&
+    sra_lower_pos(sra, ref) === nothing
+sra_ondisk_pos(sra, ref, idx) =
+    !MemPool.isinmemory(ref) &&
+    MemPool.isondisk(ref) &&
+    sra_upper_pos(sra, ref) === nothing &&
+    sra_lower_pos(sra, ref) == idx
+@testset "SimpleRecencyAllocator" begin
+    sdevice = SerializationFileDevice()
 
-    @test inmem(r1)
-    @test inmem(r2)
-    @test inmem(r3)
+    # Garbage policy throws on creation
+    @test_throws ArgumentError SimpleRecencyAllocator(1, sdevice, 1, :blah)
 
-    r4 = poolset([1], 2)
-    @test !inmem(r1)
-    @test inmem(r2)
-    @test inmem(r3)
-    @test lru_upper_pos(r4) == 1
-    @test lru_upper_pos(r3) == 2
-    @test lru_upper_pos(r2) == 3
-    @test lru_lower_pos(r1) == 1
-    @test lru_upper_pos(r1) === nothing
-    poolget(r2) # make this most recently used
-    @test poolget(r2) isa Vector
-    @test lru_upper_pos(r2) == 1
-    @test lru_upper_pos(r4) == 2
-    @test lru_upper_pos(r3) == 3
+    # Memory and disk limits must be positive and non-zero
+    @test_throws ArgumentError SimpleRecencyAllocator(0, sdevice, 1, :LRU)
+    @test_throws ArgumentError SimpleRecencyAllocator(1, sdevice, 0, :LRU)
+    @test_throws ArgumentError SimpleRecencyAllocator(0, sdevice, -1, :LRU)
+    @test_throws ArgumentError SimpleRecencyAllocator(-1, sdevice, 0, :LRU)
 
-    #destroyonevict(r3)
-    r5 = poolset([1,2],2)
-    # equivalent to destroyonevict
-    r3_id = (r3.owner, r3.id)
-    r3 = nothing; GC.gc(); sleep(1); wait(@spawnat 2 GC.gc())
-    @test remotecall_fetch(id->!haskey(MemPool.datastore, id), r3_id[1], r3_id[2])
-    @test inmem(r2)
-    @test lru_upper_pos(r2) == 2
+    for sra in [MemPool.SimpleRecencyAllocator(8*10, sdevice, 8*10_000, :LRU),
+                MemPool.SimpleRecencyAllocator(8*10, sdevice, 8*10_000, :MRU)]
+        r1 = poolset([1,2]; device=sra)
+        r2 = poolset([1,2,3]; device=sra)
+        r3 = poolset([1,2,3,4,5]; device=sra)
 
-    r6 = poolset([1,2],2)
-    @test inmem(r2)
-    @test inmem(r4)
+        @test sra_inmem_pos(sra, r3, 1)
+        @test sra_inmem_pos(sra, r2, 2)
+        @test sra_inmem_pos(sra, r1, 3)
+        for ref in [r1, r2, r3]
+            @test haskey(sra.ref_cache, ref.id)
+            @test sra.ref_cache[ref.id] === MemPool.datastore[ref.id]
+        end
 
-    # slightly bulky object
-    r7 = poolset(collect(1:11),2)
-    @test !inmem(r7) # immediate demotion
-    # existing refs not touched
-    @test all(inmem.([r2,r4,r5,r6]))
-    @test !inmem(r1)
+        # Add a ref that causes an eviction
+        r4 = poolset([1,2]; device=sra)
+        @test sra_inmem_pos(sra, r4, 1)
+        if sra.policy == :LRU
+            @test sra_inmem_pos(sra, r3, 2)
+            @test sra_inmem_pos(sra, r2, 3)
+            @test sra_ondisk_pos(sra, r1, 1)
+        else
+            @test sra_inmem_pos(sra, r2, 2)
+            @test sra_inmem_pos(sra, r1, 3)
+            @test sra_ondisk_pos(sra, r3, 1)
+        end
 
-    upper_refs = lru_upper_refs(2)
-    lower_refs = lru_lower_refs(2)
-    # very bulky object
-    try
-        poolset(collect(1:10_001),2)
-        @test false
-    catch err
-        @test err.captured.ex isa ArgumentError
+        # Make an in-memory ref the most recently used
+        @test poolget(r2) == [1,2,3]
+        @test sra_inmem_pos(sra, r2, 1)
+        if sra.policy == :LRU
+            @test sra_inmem_pos(sra, r4, 2)
+            @test sra_inmem_pos(sra, r3, 3)
+            @test sra_ondisk_pos(sra, r1, 1)
+        else
+            @test sra_inmem_pos(sra, r4, 2)
+            @test sra_inmem_pos(sra, r1, 3)
+            @test sra_ondisk_pos(sra, r3, 1)
+        end
+
+        # Make an on-disk ref the most recently used
+        if sra.policy == :LRU
+            @test poolget(r1) == [1,2]
+            @test sra_inmem_pos(sra, r1, 1)
+            @test sra_inmem_pos(sra, r2, 2)
+            @test sra_inmem_pos(sra, r4, 3)
+            @test sra_ondisk_pos(sra, r3, 1)
+        else
+            @test poolget(r3) == [1,2,3,4,5]
+            @test sra_inmem_pos(sra, r3, 1)
+            @test sra_inmem_pos(sra, r4, 2)
+            @test sra_inmem_pos(sra, r1, 3)
+            @test sra_ondisk_pos(sra, r2, 1)
+        end
+
+        # Delete a ref that was in memory
+        prev_mem_refs = copy(sra.mem_refs)
+        prev_device_refs = copy(sra.device_refs)
+        local del_id
+        # FIXME: Somehow refs get retained?
+        if sra.policy == :LRU
+            del_id = r1.id
+            #r1 = nothing
+            MemPool.delete_from_device!(sra, r1)
+        else
+            del_id = r3.id
+            #r3 = nothing
+            MemPool.delete_from_device!(sra, r3)
+        end
+        @test_broken !haskey(MemPool.datastore, del_id)
+        @test !in(del_id, sra.mem_refs)
+        @test !in(del_id, sra.device_refs)
+        @test !haskey(sra.ref_cache, del_id)
+        @test sra.mem_refs == filter(id->id != del_id, prev_mem_refs)
+        @test sra.device_refs == prev_device_refs
+
+        # Delete a ref that was on disk
+        prev_mem_refs = copy(sra.mem_refs)
+        prev_device_refs = copy(sra.device_refs)
+        if sra.policy == :LRU
+            del_id = r3.id
+            #r3 = nothing
+            MemPool.delete_from_device!(sra, r3)
+        else
+            del_id = r2.id
+            #r2 = nothing
+            MemPool.delete_from_device!(sra, r2)
+        end
+        @test_broken !haskey(MemPool.datastore, del_id)
+        @test !in(del_id, sra.mem_refs)
+        @test !in(del_id, sra.device_refs)
+        @test !haskey(sra.ref_cache, del_id)
+        @test sra.mem_refs == prev_mem_refs
+        @test sra.device_refs == filter(id->id != del_id, prev_device_refs)
+
+        # Try to add a bulky object that doesn't fit in memory
+        prev_mem_refs = copy(sra.mem_refs)
+        prev_device_refs = copy(sra.device_refs)
+        r7 = poolset(collect(1:11))
+        @test_throws ArgumentError MemPool.set_device!(sra, r7)
+        @test sra.mem_refs == prev_mem_refs
+        @test sra.device_refs == prev_device_refs
+        @test !haskey(sra.ref_cache, r7.id)
+
+        # Add a bulky object that doesn't fit in memory or on disk
+        prev_mem_refs = sra.mem_refs
+        prev_device_refs = sra.device_refs
+        r8 = poolset(collect(1:10_001))
+        @test_throws ArgumentError MemPool.set_device!(sra, r8)
+        @test sra.mem_refs == prev_mem_refs
+        @test sra.device_refs == prev_device_refs
+        @test !haskey(sra.ref_cache, r8.id)
     end
-    # failure to insert doesn't affect existing refs
-    @test lru_upper_refs(2) == upper_refs
-    @test lru_lower_refs(2) == lower_refs
 
-    # !inmem(r1)
-    # promote r1 to memory
-    @test poolget(r1) isa Vector
-    @test inmem(r1) == 1
-    @test all(inmem.([r2,r4,r5,r6]))
-    @test !inmem(r7)
-
-    r8 = poolset(collect(1:9_989),2)
-    # can still get swapped-in data
-    @test map(poolget, [r1,r2,r4,r5,r6]) == [[1:2;], [1:3;], [1], [1:2;], [1:2;]]
-    # bulky object can't migrate
-    try
-        poolget(r8)
-        @test false
-    catch err
-        @test err.captured.ex isa AssertionError
-    end
-    # can forcibly retrieve bulky objects (but we're hiding it from the allocator)
-    @test MemPool.readfromdevice(r7) == [1:11;]
-    @test MemPool.readfromdevice(r8) == [1:9_989;]
-
-    r1, r2, r4, r5, r6, r7, r8 = nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing
-    GC.gc(); sleep(1); wait(@spawnat 2 GC.gc())
-
-    @everywhere MemPool.GLOBAL_DEVICE[] = $old_alloc
+    # Whole-device retention applies to all objects
+    dirname = mktempdir()
+    sdevice2 = SerializationFileDevice(dirname)
+    sra = MemPool.SimpleRecencyAllocator(8*10, sdevice2, 8*10_000, :LRU)
+    refs = [poolset(123; device=sra) for i in 1:8]
+    @test isempty(sra.device_refs)
+    MemPool.retain_on_device!(sra, true)
+    # Retention is lazy
+    @test isempty(sra.device_refs)
+    @test length(readdir(dirname)) == 0
+    # Retention occurs on deletion
+    refs = nothing; GC.gc(); sleep(0.5)
+    @test isempty(sra.mem_refs)
+    @test isempty(sra.device_refs)
+    @test length(readdir(dirname)) == 8
 end
+
+@testset "Mountpoints and Disk Stats" begin
+    mounts = MemPool.mountpoints()
+    @test mounts isa Vector{String}
+    @test length(mounts) > 0
+    if Sys.iswindows()
+        @test "C:" in mounts
+    else
+        @test "/" in mounts
+    end
+    for mount in mounts
+        if ispath(mount)
+            stats = MemPool.disk_stats(mount)
+            @test stats.available > 0
+            @test stats.capacity > 0
+            @test stats.available < stats.capacity
+        end
+    end
+end
+
+@testset "High-level APIs" begin
+    sdevice = SerializationFileDevice()
+    devices = [CPURAMDevice(),
+               sdevice,
+               SimpleRecencyAllocator(8, sdevice, 1024^3, :LRU)]
+
+    # Resource queries work correctly
+    for device in devices
+        resources = MemPool.storage_resources(device)
+        @test length(resources) >= 1
+        @test length(unique(resources)) == length(resources)
+        for resource in resources
+            @test MemPool.storage_capacity(device, resource) > 0
+            @test MemPool.storage_available(device, resource) >= 0
+            @test MemPool.storage_utilized(device, resource) >= 0
+
+            @test MemPool.externally_varying(device) isa Bool
+            if !MemPool.externally_varying(device)
+                @test MemPool.storage_capacity(device, resource) ==
+                      MemPool.storage_available(device, resource) +
+                      MemPool.storage_utilized(device, resource)
+            end
+        end
+
+        # Wrong resource passed to resource queries throw errors
+        wrong_res = MemPool.FilesystemResource("/fake/path")
+        @test_throws ArgumentError MemPool.storage_capacity(device, wrong_res)
+        @test_throws ArgumentError MemPool.storage_available(device, wrong_res)
+        @test_throws ArgumentError MemPool.storage_utilized(device, wrong_res)
+    end
+
+    # All APIs accept either DRef, ref ID, or RefState as identifier
+    # Either state or device may be passed
+    # Redundant set, read, write, retain, delete are allowed
+    # Non-read calls return nothing
+    # set_device! sets root and leaf
+    for device in devices
+        x1 = poolset(123)
+        state = MemPool.datastore[x1.id]
+
+        # set_device! requires access to ref ID and device to set
+        @test MemPool.set_device!(device, x1) ===
+              MemPool.set_device!(device, state, x1) ===
+              MemPool.set_device!(device, x1.id) ===
+              MemPool.set_device!(device, state, x1.id) ===
+              nothing
+
+        @test MemPool.isinmemory(x1) ==
+              MemPool.isinmemory(x1.id) ==
+              MemPool.isinmemory(state)
+        @test MemPool.isondisk(x1) ==
+              MemPool.isondisk(x1.id) ==
+              MemPool.isondisk(state)
+
+        # Root and leaf are set appropriately
+        sstate = storage_read(state)
+        @test sstate.root === device
+        if device isa CPURAMDevice
+            @test length(sstate.leaves) == 0
+        elseif device isa SerializationFileDevice
+            @test length(sstate.leaves) == 1
+            @test first(sstate.leaves).device === device
+        elseif device isa SimpleRecencyAllocator
+            x2 = poolset(456; device) # to push x1 to disk
+            @test first(storage_read(state).leaves).device !== device
+        end
+
+        @test MemPool.read_from_device(state, x1, true) ==
+              MemPool.read_from_device(device, x1, true) ==
+              MemPool.read_from_device(device, state, x1, true) ==
+              MemPool.read_from_device(state, x1.id, true) ==
+              MemPool.read_from_device(device, x1.id, true) ==
+              MemPool.read_from_device(device, state, x1.id, true)
+
+        # When ret == false, nothing is returned
+        @test MemPool.read_from_device(state, x1, false) ===
+              MemPool.read_from_device(device, x1, false) ===
+              MemPool.read_from_device(device, state, x1, false) ===
+              MemPool.read_from_device(state, x1.id, false) ===
+              MemPool.read_from_device(device, x1.id, false) ===
+              MemPool.read_from_device(device, state, x1.id, false) ===
+              nothing
+
+        @test MemPool.write_to_device!(state, x1) ===
+              MemPool.write_to_device!(device, x1) ===
+              MemPool.write_to_device!(device, state, x1) ===
+              MemPool.write_to_device!(state, x1.id) ===
+              MemPool.write_to_device!(device, x1.id) ===
+              MemPool.write_to_device!(device, state, x1.id) ===
+              nothing
+
+        for mode in [true, false]
+            @test MemPool.retain_on_device!(state, x1, mode; all=true) ===
+                  MemPool.retain_on_device!(device, x1, mode; all=true) ===
+                  MemPool.retain_on_device!(device, state, x1, mode; all=true) ===
+                  MemPool.retain_on_device!(state, x1.id, mode; all=true) ===
+                  MemPool.retain_on_device!(device, x1.id, mode; all=true) ===
+                  MemPool.retain_on_device!(device, state, x1.id, mode; all=true) ===
+                  nothing
+        end
+
+        @test MemPool.delete_from_device!(state, x1) ===
+              MemPool.delete_from_device!(device, x1) ===
+              MemPool.delete_from_device!(device, state, x1) ===
+              MemPool.delete_from_device!(state, x1.id) ===
+              MemPool.delete_from_device!(device, x1.id) ===
+              MemPool.delete_from_device!(device, state, x1.id) ===
+              nothing
+
+        # Delete clears all leaf devices
+        @test length(storage_read(state).leaves) == 0
+    end
+
+    # Garbage ref IDs passed to APIs which don't take a RefState always throw
+    for device in devices
+        @test_throws Exception MemPool.set_device!(device, typemax(Int))
+        @test_throws Exception MemPool.read_from_device(device, typemax(Int), true)
+        @test_throws Exception MemPool.write_to_device!(device, typemax(Int))
+        @test_throws Exception MemPool.delete_from_device!(device, typemax(Int))
+    end
+
+    @testset "set_device! failure" begin
+        # N.B. That this device doesn't fully conform to semantics
+        struct FailingWriteStorageDevice <: MemPool.StorageDevice end
+        MemPool.write_to_device!(::FailingWriteStorageDevice, ::MemPool.RefState, ::Any) =
+            error("Failed to write")
+
+        # Allocate directly throws and does not have datastore entry
+        GC.gc(); sleep(1)
+        len = length(MemPool.datastore)
+        @test_throws ErrorException poolset(123; device=FailingWriteStorageDevice())
+        GC.gc(); sleep(1)
+        @test length(MemPool.datastore) == len
+
+        # Allocate, then set, throws and has datastore entry
+        x = poolset(123)
+        @test_throws ErrorException MemPool.set_device!(FailingWriteStorageDevice(), x)
+        @test haskey(MemPool.datastore, x.id)
+    end
+
+    # Retention can be set in poolset
+    x1 = poolset(123; device=sdevice)
+    @test !only(storage_read(MemPool.datastore[x1.id]).leaves).retain
+    x1 = poolset(123; device=sdevice, retain=true)
+    @test only(storage_read(MemPool.datastore[x1.id]).leaves).retain
+    MemPool.retain_on_device!(sdevice, x1, false)
+end
+
+#= TODO
+Allocate, write non-CPU A, write non-CPU B, handle for A was explicitly deleted
+Allocate, chain write and reads such that write starts before, and finishes after, read, ensure ordering is correct
+Stress RCU with many readers and one write-delete-read task
+=#
 
 @testset "who_has_read" begin
     f = tempname()
@@ -334,17 +816,4 @@ end
     fref = savetodisk(ref, f)
     r2 = remotecall_fetch(()->MemPool.poolget(fref), 2)
     @test MemPool.who_has_read[f][1].owner == 2
-end
-
-@testset "cleanup" begin
-    @everywhere MemPool.cleanup()
-    for w in [1, 2]
-        d = joinpath(@__DIR__, MemPool.default_dir(w))
-        if isdir(d)
-            @test isempty(readdir(d))
-            rm(d; recursive=true)
-        else
-            @test true
-        end
-    end
 end


### PR DESCRIPTION
This PR implements support for "storage devices", which represent memory, disks, and storage manager algorithms that MemPool can leverage to perform automatic data management. We implement an `SimpleRecencyAllocator` device which, when assigned to one or more `DRef`s (via a `poolset` kwarg), will manage migrating refs from memory to disk (or really between any two devices) as memory fills up, and from disk to memory as data is accessed via `poolget`.

The `SimpleRecencyAllocator` isn't intended to be a perfect, all-encompassing storage manager; instead, it's a simple example of how to do memory management in this new scheme. Interested users are encouraged to implement their own storage devices and managers to suit their workload.

This is also intended as a replacement for some of the logic in https://github.com/JuliaParallel/Dagger.jl/pull/289. This PR should be better able to prevent in-memory data and files on disk from lingering for longer than they're needed, and should give a storage manager fine-grained control over data migration decisions. It doesn't currently integrate metrics about data migration speeds and data compression ratios (which Dagger would want to know), but we should be able to easily expose those metrics later on.

Todo:
- [x] Add tests for `SimpleRecencyAllocator`
- [x] Add MRU support
- [x] Add docs for writing storage devices
- [x] Add tests for `CPURAMDevice` and `SerializationFileDevice`
- [x] Ensure LRU promotes data to upper device during `read_from_device`
- [x] Expose resource queries (available, capacity)
- [x] Test resource queries
- [x] Try to make all storage-related GC finalizers non-yielding
- [x] Clean-up refcounting debug statements
- [ ] Add file name pattern callback to `SerializationFileDevice`
- [x] Test refcounting implementation
- [x] Update API names to use underscores
- [ ] Test nested LRU
- [ ] Stress-test concurrent access
- [x] Support `retain` alternative to `destroyonevict` and test it
- [ ] Test multiple leaf devices
- [x] Add Windows disk query method
- [x] Use `Base.diskstats` if available
- [x] ~Determine how to support aliased storage resources~ Out of scope for now
- [x] Ensure that errors propagate correctly and do not hang the system
- [x] Update https://github.com/JuliaParallel/Dagger.jl/pull/289 for this PR
- [x] Add mechanism to ensure lazy tasks complete during `atexit`
- [x] Add stream filters to `SerializationDiskDevice` for compression/encryption/etc.