### PR TITLE
storage: Add root and leaf tags

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -43,16 +43,27 @@ struct FileRef
     function FileRef(file, size; pid=nothing)
         new(host, file, size, Ref{Union{Int, Nothing}}(pid))
     end
+    function FileRef(file; pid=nothing)
+        size = try
+            UInt(Base.stat(file).size)
+        catch err
+            @debug "Failed to query FileRef size of $file"
+            UInt(0)
+        end
+        new(host, file, size, Ref{Union{Int, Nothing}}(pid))
+    end
 end
 
 unwrap_payload(f::FileRef) = unwrap_payload(open(deserialize, f.file, "r+"))
+
+approx_size(f::FileRef) = f.size
 
 include("io.jl")
 include("lock.jl")
 include("datastore.jl")
 
 """
-`approx_size(d)`
+    approx_size(d)
 
 Returns the size of `d` in bytes used for accounting in MemPool datastore.
 """


### PR DESCRIPTION
Prior to this commit, because it was not possible to decide what
specific files are read from/written to, MemPool was only really useful
for automated swap-to-disk setups. In many realistic scenarios, users
have either existing files that they'd like MemPool to access, or they
want MemPool to write their files with specific and predictable names,
to be consumed by other code or future Julia sessions.

This commit provides this functionality in the form of "tags": a tag is
arbitrary data attached to a `DRef` which is associated with a specific
type of root or leaf device; in the case of `SerializationFileDevice`,
it is a `String` which is the filename that should be used to read/write
the file. Tags are the mechanism by which the user can communicate
specific configurations to storage devices, and they may take on any
value that the device chooses (and multiple such configuration values
could be specified as a `NamedTuple`, `Dict`, etc.). Tags may be set at
`poolset` time, individually for the root device and each possible leaf
device type.

To enable use cases where files already exist and the user wishes to use
them as lazily-accessible data sources, a `restore` flag is added to
`poolset` to treat the provided data as a leaf device handle, along with
a `leaf_device` kwarg to specify which device it is associated with.
This will treat the data as already being in the appropriate format on
the device, and together with tags and `retain=true`, will allow for
files to be lazily and non-destructively read in by MemPool.

This commit also generalizes the `SerializationFileDevice` by creating a
`GenericFileDevice`, which allows the user to specify custom
serialization and deserialization functions as type parameters. This
allows for easily reading/writing XML, JLD, HDF5, PNG, etc. files by
just constructing a `GenericFileDevice` with the correct pair of ser/des
functions. It also has a type parameter to choose between `IO`-based and
`String`-based ser/des functions, in case the provided ser/des functions
only accept `String`s. `String`-based ser/des functions are not
compatible with filters, and an error will be thrown if any are
registered. The existing `SerializationFileDevice` is now just an alias
to a concrete `GenericFileDevice` type.

Finally, this commit makes the retention behavior of
`SimpleRecencyAllocator` eager, thus immediately moving retained refs to
the device if necessary. This helps enable use cases where registered
refs are persisted to disk for usage in future sessions.