### PR TITLE
SimpleRecencyAllocator: Decr ctrs in delete_from_device

### DIFF
--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -521,8 +521,8 @@ function setup_global_device!(cfg::DiskCacheConfig)
         # This detects if a disk cache was already set up
         @warn(
             "Setting the disk cache config when one is already set will lead to " *
-            "unexpected behavior and likely cause issues. Please restart the process" *
-            "before changing the disk cache configuration." *
+            "unexpected behavior and likely cause issues. Please restart the process " *
+            "before changing the disk cache configuration. " *
             "If this warning is unexpected you may need to " *
             "clear the `JULIA_MEMPOOL_EXPERIMENTAL_FANCY_ALLOCATOR` ENV."
         )

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1013,12 +1013,14 @@ function delete_from_device!(sra::SimpleRecencyAllocator, state::RefState, id::I
         if (idx = findfirst(x->x==id, sra.mem_refs)) !== nothing
             delete_from_device!(CPURAMDevice(), state, id)
             deleteat!(sra.mem_refs, idx)
+            sra.mem_size[] -= state.size
         end
         if (idx = findfirst(x->x==id, sra.device_refs)) !== nothing
             if !sra.retain[]
                 delete_from_device!(sra.device, state, id)
             end
             deleteat!(sra.device_refs, idx)
+            sra.device_size[] -= state.size
         end
         delete!(sra.ref_cache, id)
     end


### PR DESCRIPTION
We didn't properly maintain the size counters, causing the SRA to bail out, thinking it had no space available. Addresses issues reported in https://github.com/JuliaParallel/DTables.jl/issues/60.