### PR TITLE
poolset: Call GC when free mem is low

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '~1.7'
           - '~1.8'
           - '~1.9'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 DataStructures = "0.18"
-julia = "1.7"
+ScopedValues = "1"
+julia = "1.8"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -118,6 +118,10 @@ function __init__()
     DISKCACHE_CONFIG[] = diskcache_config = DiskCacheConfig()
     setup_global_device!(diskcache_config)
 
+    if haskey(ENV, "JULIA_MEMPOOL_MEMORY_RESERVED")
+        MEM_RESERVED[] = parse(UInt, ENV["JULIA_MEMPOOL_MEMORY_RESERVED"])
+    end
+
     # Ensure we cleanup all references
     atexit(exit_hook)
 end

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -4,6 +4,7 @@ using Serialization, Sockets, Random
 import Serialization: serialize, deserialize
 export DRef, FileRef, poolset, poolget, mmwrite, mmread, cleanup
 import .Threads: ReentrantLock
+using ScopedValues
 
 ## Wrapping-unwrapping of payloads:
 

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -186,6 +186,7 @@ QueriedMemInfo() = QueriedMemInfo(UInt64(0), UInt64(0))
 const QUERY_MEM_AVAILABLE = Ref(QueriedMemInfo())
 const QUERY_MEM_CAPACITY = Ref(QueriedMemInfo())
 const QUERY_MEM_PERIOD = 10 * 1000^2 # 10ms
+const QUERY_MEM_OVERRIDE = ScopedValue(false)
 function _query_mem_periodically(kind::Symbol)
     if !(kind in (:available, :capacity))
         throw(ArgumentError("Invalid memory query kind: $kind"))
@@ -197,7 +198,7 @@ function _query_mem_periodically(kind::Symbol)
     end
     mem_info = mem_bin[]
     now_ns = time_ns()
-    if mem_info.last_ns < now_ns - QUERY_MEM_PERIOD
+    if QUERY_MEM_OVERRIDE[] || mem_info.last_ns < now_ns - QUERY_MEM_PERIOD
         if kind == :available
             new_mem_info = QueriedMemInfo(free_memory(), now_ns)
         elseif kind == :capacity


### PR DESCRIPTION
This PR attempts to work around memory usage issues in a similar manner to the Julia GPU packages: when `poolset` is called, if we're running low on memory (according to a configurable threshold), then we do increasingly expensive calls to the GC to try to free up enough memory to avoid an OOM.

An enhancement that we could make is to keep trying to GC until we don't free any memory. To be investigated.

@stevenwhitaker @svilupp this might help with the OOM issues seen with your workloads.

@krynju I'm considering enabling this by default, do you have any objections to that?