### PR TITLE
poolset: Add optional destructor function

### DIFF
--- a/src/storage.jl
+++ b/src/storage.jl
@@ -309,9 +309,11 @@ mutable struct RefState
     # Metadata to associate with the reference
     tag::Any
     leaf_tag::Tag
+    # Destructor, if any
+    destructor::Any
 end
 RefState(storage::StorageState, size::Integer) =
-    RefState(storage, size, nothing, Tag())
+    RefState(storage, size, nothing, Tag(), nothing)
 function Base.getproperty(state::RefState, field::Symbol)
     if field === :storage
         throw(ArgumentError("Cannot directly read `:storage` field of `RefState`\nUse `storage_read(state)` instead"))


### PR DESCRIPTION
MemPool's usage of distributed refcounting and GC finalizers causes slightly excessive memory retention, because it takes sometimes some extra time or an extra GC cycle to clean up data that's been `poolset` once all `DRef`s are freed.

This PR adds an optional user-defined "destructor" callback, which is invoked when an object that's been `poolset` becomes no longer referenced by any `DRef` (which can allow eagerly cleaning up associated memory, rather than letting the GC figure it out on its own). This will be used by Dagger to allow cleaning up cached Dagger task results once all user references are deleted, and the scheduler determines that it no longer needs to use that data. This can cause memory usage to be better controlled when Dagger (and MemPool) are tracking large amounts of data.