### PR TITLE
Add DRef migration support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         julia-version:
           - '~1.8'
           - '~1.9'
+          - '~1.10'
           - 'nightly'
       fail-fast: false
     name: Test with Julia ${{ matrix.julia-version }}

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.6"
 
 [deps]
 ConcurrentCollections = "5060bff5-0b44-40c5-b522-fcd3ca5cecdd"
+ConcurrentUtils = "3df5f688-6c4c-4767-8685-17f5ad261477"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -16,6 +17,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 ConcurrentCollections = "0.1"
+ConcurrentUtils = "0.1"
 DataStructures = "0.18"
 ScopedValues = "1"
 julia = "1.8"

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -315,9 +315,18 @@ mutable struct RefState
     leaf_tag::Tag
     # Destructor, if any
     destructor::Any
+    # A Reader-Writer lock to protect access to this struct
+    lock::CU.ReadWriteLock
+    # The DRef that this value may be redirecting to
+    redirect::Union{DRef,Nothing}
 end
-RefState(storage::StorageState, size::Integer) =
-    RefState(storage, size, nothing, Tag(), nothing)
+RefState(storage::StorageState, size::Integer;
+         tag=nothing, leaf_tag=Tag(),
+         destructor=nothing) =
+    RefState(storage, size,
+             tag, leaf_tag,
+             destructor,
+             CU.ReadWriteLock(), nothing)
 function Base.getproperty(state::RefState, field::Symbol)
     if field === :storage
         throw(ArgumentError("Cannot directly read `:storage` field of `RefState`\nUse `storage_read(state)` instead"))


### PR DESCRIPTION
This PR allows DRefs to be migrated from their current worker to another worker, and have future accesses to the DRef be seamlessly redirected to the new owner. Multiple migrations of the same DRef may occur, and a caching layer will ensure that redirects only add overhead on the first access from each worker after a migration has occurred.

Todo:
- [ ] Add docstring
- [ ] Add tests