### PR TITLE
Add a type assertion to remove some invalidations

### DIFF
--- a/src/storage.jl
+++ b/src/storage.jl
@@ -879,8 +879,10 @@ function sra_migrate!(sra::SimpleRecencyAllocator, state::RefState, ref_id, to_m
     # and go to the "to" device. The passed-in ref is inserted into the
     # "from" device.
     if ismissing(to_mem)
-        # Try to minimize reads/writes
-        sstate = storage_read(state)
+        # Try to minimize reads/writes. Note the type assertion to help the
+        # compiler with inference, this removes some Base._any() invalidations.
+        sstate::StorageState = storage_read(state)
+
         if sstate.data !== nothing
             # Try to keep it in memory
             to_mem = true


### PR DESCRIPTION
This removes about 55 invalidations from `Base._any()`, which is called by `any()` which is called by `sra_migrate!()`. Not sure why `storage_read()` fails to infer by itself, perhaps because it's using atomics?

Before:
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐                                                     
│ <file name>:<line number>                                                                                                         │  Function Name   │ Invalidations │ Invalidations % │                                                     
│                                                                                                                                   │                  │               │     (xᵢ/∑x)     │                                                     
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2375 │       _any       │      90       │       22        │
```

After:
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐                                                     
│ <file name>:<line number>                                                                                                         │  Function Name   │ Invalidations │ Invalidations % │                                                     
│                                                                                                                                   │                  │               │     (xᵢ/∑x)     │                                                     
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤                                                     
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2375 │       _any       │      35       │       14        │                                                     
```

This is the invalidation tree for this particular invalidation:
```julia
julia> show(trees[end].backedges[end]; maxdepth=30, minchildren=0)                                                                                                                                                                             
MethodInstance for Base._any(::MemPool.var"#107#115"{MemPool.SimpleRecencyAllocator}, ::AbstractArray, ::Colon) (36 children)                                                                                                                  
 MethodInstance for Base.var"#any#849"(::Colon, ::typeof(any), ::MemPool.var"#107#115"{MemPool.SimpleRecencyAllocator}, ::AbstractArray) (35 children)                                                                                         
  MethodInstance for any(::MemPool.var"#107#115"{MemPool.SimpleRecencyAllocator}, ::AbstractArray) (34 children)                                                                                                                               
   MethodInstance for MemPool.var"#sra_migrate!#106"(::Bool, ::Bool, ::typeof(MemPool.sra_migrate!), ::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Missing) (0 children)                                                    
   MethodInstance for MemPool.var"#sra_migrate!#106"(::Bool, ::Bool, ::typeof(MemPool.sra_migrate!), ::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Bool) (32 children)                                                      
    MethodInstance for Core.kwcall(::@NamedTuple{read::Bool, locked::Bool}, ::typeof(MemPool.sra_migrate!), ::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Bool) (31 children)                                               
     MethodInstance for (::MemPool.var"#127#130"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (9 children)                                                                                                                      
      MethodInstance for MemPool.with_lock(::MemPool.var"#127#130"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64}, ::MemPool.NonReentrantLock, ::Bool) (8 children)                                                                  
       MethodInstance for MemPool.with_lock(::MemPool.var"#127#130"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64}, ::MemPool.NonReentrantLock) (7 children)                                                                         
        MethodInstance for MemPool.delete_from_device!(::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64) (6 children)                                                                                                             
         MethodInstance for (::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (0 children)                                                                                                            
         MethodInstance for (::MemPool.var"#127#130"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (0 children)                                                                                                                  
         MethodInstance for (::MemPool.var"#201#205"{Int64})() (3 children)                                                                                                                                                                    
          MethodInstance for MemPool.with_lock(::MemPool.var"#201#205"{Int64}, ::MemPool.NonReentrantLock, ::Bool) (2 children)                                                                                                                
           MethodInstance for MemPool.with_lock(::MemPool.var"#201#205"{Int64}, ::MemPool.NonReentrantLock) (1 children)                                                                                                                       
            MethodInstance for MemPool.exit_hook() (0 children)                                                                                                                                                                                
     MethodInstance for (::MemPool.var"#123#125"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64, Bool})() (20 children)                                                                                                               
      MethodInstance for MemPool.write_to_device!(::MemPool.CPURAMDevice, ::MemPool.RefState, ::Int64) (0 children)                                                                                                                            
      MethodInstance for MemPool.with_lock(::MemPool.var"#123#125"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64, Bool}, ::MemPool.NonReentrantLock, ::Bool) (18 children)                                                           
       MethodInstance for MemPool.with_lock(::MemPool.var"#123#125"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64, Bool}, ::MemPool.NonReentrantLock) (17 children)                                                                  
        MethodInstance for MemPool.read_from_device(::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Bool) (16 children)                                                                                                       
         MethodInstance for MemPool.write_to_device!(::MemPool.CPURAMDevice, ::MemPool.RefState, ::Int64) (0 children)                                                                                                                         
         MethodInstance for (::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (0 children)                                                                                                            
         MethodInstance for MemPool.write_to_device!(::MemPool.GenericFileDevice{S, D, F, M}, ::MemPool.RefState, ::Int64) where {S, D, F, M} (0 children)                                                                                     
         MethodInstance for MemPool.read_from_device(::MemPool.CPURAMDevice, ::MemPool.RefState, ::Int64, ::Bool) (12 children)                                                                                                                
          MethodInstance for (::MemPool.var"#123#125"{MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64, Bool})() (0 children)                                                                                                           
          MethodInstance for MemPool.read_from_device(::MemPool.CPURAMDevice, ::MemPool.RefState, ::Int64, ::Bool) (0 children)                                                                                                                
          MethodInstance for (::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (0 children)
          MethodInstance for MemPool.write_to_device!(::MemPool.GenericFileDevice{S, D, F, M}, ::MemPool.RefState, ::Int64) where {S, D, F, M} (0 children)
          MethodInstance for MemPool.write_to_device!(::MemPool.CPURAMDevice, ::MemPool.RefState, ::Int64) (7 children)
           MethodInstance for (::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (6 children)
            MethodInstance for MemPool.with_lock(::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64}, ::MemPool.NonReentrantLock, ::Bool) (5 children)
             MethodInstance for MemPool.var"#sra_migrate!#106"(::Bool, ::Bool, ::typeof(MemPool.sra_migrate!), ::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Bool) (0 children)
             MethodInstance for MemPool.var"#sra_migrate!#106"(::Bool, ::Bool, ::typeof(MemPool.sra_migrate!), ::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Missing) (3 children)
              MethodInstance for MemPool.sra_migrate!(::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64, ::Missing) (2 children)
               MethodInstance for MemPool.write_to_device!(::MemPool.SimpleRecencyAllocator, ::MemPool.RefState, ::Int64) (1 children)
                MethodInstance for (::MemPool.var"#108#116"{Bool, MemPool.SimpleRecencyAllocator, MemPool.RefState, Int64})() (0 children)
```