### PR TITLE
Remove UnsafeAtomics dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"
 
 [compat]
 ConcurrentCollections = "0.1"
@@ -23,7 +22,6 @@ DataStructures = "0.18"
 DistributedNext = "1"
 Preferences = "1"
 ScopedValues = "1"
-UnsafeAtomics = "0.2"
 julia = "1.9"
 
 [extras]


### PR DESCRIPTION
This should fix nightly, although we might suffer some performance hits until https://github.com/JuliaLang/julia/pull/45122 is merged.