### PR TITLE
Disable memory reservation check by default

### DIFF
--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -386,7 +386,7 @@ isondisk(id::Int) =
 isinmemory(x::DRef) = isinmemory(x.id)
 isondisk(x::DRef) = isondisk(x.id)
 
-const MEM_RESERVED = Ref{UInt}(512 * (1024^2)) # Reserve 512MB of RAM for OS
+const MEM_RESERVED = Ref{UInt}(0) # O to avoid excessive GC
 const MEM_RESERVE_LOCK = Threads.ReentrantLock()
 const MEM_RESERVE_SWEEPS = Ref{Int}(3)
 


### PR DESCRIPTION
Otherwise it causes really excessive numbers of GC calls on memory constrained systems like laptops and desktops.