### PR TITLE
update DataStructures to 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.4.13"
 
 [deps]
 ConcurrentCollections = "5060bff5-0b44-40c5-b522-fcd3ca5cecdd"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DistributedNext = "fab6aee4-877b-4bac-a744-3eca44acbb6f"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -18,7 +17,6 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 ConcurrentCollections = "0.1"
-DataStructures = "0.18, 0.19"
 DistributedNext = "1"
 Preferences = "1"
 ScopedValues = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 ConcurrentCollections = "0.1"
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 DistributedNext = "1"
 Preferences = "1"
 ScopedValues = "1"


### PR DESCRIPTION
I'm having an issue with unsatisfiable dependency requirements and it seems like DataStructures dep here is not up to date.